### PR TITLE
Normalize relative paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,14 +39,19 @@ module.exports = function (str, opts) {
 		delete urlObj.port;
 	}
 
+	// remove duplicate slashes
+	urlObj.pathname = urlObj.pathname.replace(/\/{2,}/, '/');
+
+	// resolve relative paths
+	var domain = urlObj.protocol + '//' + urlObj.hostname;
+	var relative = url.resolve(domain, urlObj.pathname);
+	urlObj.pathname = relative.replace(domain, '');
+
 	// IDN to Unicode
 	urlObj.hostname = punycode.toUnicode(urlObj.hostname).toLowerCase();
 
 	// remove `www.`
 	urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
-
-	// remove duplicate slashes
-	urlObj.pathname = urlObj.pathname.replace(/\/{2,}/, '/');
 
 	// remove URL with empty query string
 	if (urlObj.search === '?') {

--- a/test.js
+++ b/test.js
@@ -23,5 +23,7 @@ test(function (t) {
 	t.assert(nu('//sindresorhus.com/', {normalizeProtocol: false}) === '//sindresorhus.com');
 	t.assert(nu('//sindresorhus.com:80/', {normalizeProtocol: false}) === '//sindresorhus.com');
 	t.assert(nu('http://sindresorhus.com/foo#bar') === 'http://sindresorhus.com/foo');
+	t.assert(nu('http://chrisdry.wp/wp-content/themes/scribe/css/../fonts/Pe-icon-7-stroke.eot') === 'http://chrisdry.wp/wp-content/themes/scribe/fonts/Pe-icon-7-stroke.eot');
+	t.assert(nu('http://chrisdry.wp/wp-content/themes/scribe/./fonts/Pe-icon-7-stroke.eot') === 'http://chrisdry.wp/wp-content/themes/scribe/fonts/Pe-icon-7-stroke.eot')
 	t.end();
 });


### PR DESCRIPTION
Trims out unnecessary directory traversal (`./` & `../`).

**Removing dot-segments**. The segments “..” and “.” can be removed from a URL according to the algorithm described in RFC 3986 (or a similar algorithm). Example:
`http://www.example.com/../a/b/../c/./d.html` → `http://www.example.com/a/c/d.html`

http://en.wikipedia.org/wiki/URL_normalization#Normalizations_that_usually_preserve_semantics

