### PR TITLE
Adding option for skipping remove of www

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (str, opts) {
 	opts = objectAssign({
 		normalizeProtocol: true,
 		stripFragment: true,
-		removeWWW: true,
+		stripWWW: true,
 	}, opts);
 
 	if (typeof str !== 'string') {
@@ -57,7 +57,7 @@ module.exports = function (str, opts) {
 	urlObj.hostname = punycode.toUnicode(urlObj.hostname).toLowerCase();
 
 	// remove `www.`
-	if (opts.removeWWW) {
+	if (opts.stripWWW) {
 		urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
 	}
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ var DEFAULT_PORTS = {
 module.exports = function (str, opts) {
 	opts = objectAssign({
 		normalizeProtocol: true,
-		stripFragment: true
+		stripFragment: true,
+		removeWWW: true,
 	}, opts);
 
 	if (typeof str !== 'string') {
@@ -56,7 +57,9 @@ module.exports = function (str, opts) {
 	urlObj.hostname = punycode.toUnicode(urlObj.hostname).toLowerCase();
 
 	// remove `www.`
-	urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
+	if (opts.removeWWW) {
+		urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
+	}
 
 	// remove URL with empty query string
 	if (urlObj.search === '?') {

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,23 @@ normalizeUrl('sindresorhus.com/about.html#contact', {stripFragment: false});
 //=> http://sindresorhus.com/about.html#contact
 ```
 
+##### stripWWW
+
+Type: `boolean`  
+Default: `true`
+
+Remove www from the URL if present.
+
+```js
+normalizeUrl('http://www.sindresorhus.com/about.html#contact', {stripWWW: true});
+//=> http://sindresorhus.com/about.html#contact
+```
+
+```js
+normalizeUrl('http://www.sindresorhus.com/about.html#contact', {stripWWW: false});
+//=> http://www.sindresorhus.com/about.html#contact
+```
+
 ## License
 
 MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/test.js
+++ b/test.js
@@ -31,8 +31,8 @@ test(function (t) {
 
 test(function testRemoveWWW(t) {
 	var opts = {removeWWW: false};
-  t.assert(nu('http://www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
-  t.assert(nu('www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
-  t.assert(nu('http://www.xn--xample-hva.com', opts) === 'http://www.êxample.com');
-  t.end();
+	t.assert(nu('http://www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
+	t.assert(nu('www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
+	t.assert(nu('http://www.xn--xample-hva.com', opts) === 'http://www.êxample.com');
+	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -28,3 +28,11 @@ test(function (t) {
 	t.assert(nu('http://sindresorhus.com/foo/bar/./baz') === 'http://sindresorhus.com/foo/bar/baz');
 	t.end();
 });
+
+test(function testRemoveWWW(t) {
+	var opts = {removeWWW: false};
+  t.assert(nu('http://www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
+  t.assert(nu('www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
+  t.assert(nu('http://www.xn--xample-hva.com', opts) === 'http://www.êxample.com');
+  t.end();
+});

--- a/test.js
+++ b/test.js
@@ -29,8 +29,8 @@ test(function (t) {
 	t.end();
 });
 
-test(function testRemoveWWW(t) {
-	var opts = {removeWWW: false};
+test(function testStripWWW(t) {
+	var opts = {stripWWW: false};
 	t.assert(nu('http://www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
 	t.assert(nu('www.sindresorhus.com', opts) === 'http://www.sindresorhus.com');
 	t.assert(nu('http://www.xn--xample-hva.com', opts) === 'http://www.êxample.com');


### PR DESCRIPTION
Currently this library always remove www from urls after they have been
normalized. With this pull request users can give option which gives
them control over the "remove www" for given urls. This can be used
as follows

    var nu = require('./');
    var text = 'www.sindresorhus.com';
    var opts = {removeWWW: false};
    var res = nu(text, opts);

    //=> http://www.sindresorhus.com

-

fixes #10 