### PR TITLE
fixing exception on unknown protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,19 @@ var DEFAULT_PORTS = {
 	'https:': 443,
 	'ftp:': 21
 };
+// protocols that always contain a // bit.
+const slashedProtocol = {
+	'http': true,
+	'https': true,
+	'ftp': true,
+	'gopher': true,
+	'file': true,
+	'http:': true,
+	'https:': true,
+	'ftp:': true,
+	'gopher:': true,
+	'file:': true
+};
 
 module.exports = function (str, opts) {
 	opts = objectAssign({
@@ -46,12 +59,16 @@ module.exports = function (str, opts) {
 	}
 
 	// remove duplicate slashes
-	urlObj.pathname = urlObj.pathname.replace(/\/{2,}/, '/');
+	if (urlObj.pathname) {
+		urlObj.pathname = urlObj.pathname.replace(/\/{2,}/, '/');
+	}
 
 	// resolve relative paths
 	var domain = urlObj.protocol + '//' + urlObj.hostname;
-	var relative = url.resolve(domain, urlObj.pathname);
-	urlObj.pathname = relative.replace(domain, '');
+	var relative = url.resolve(domain, urlObj.pathname || '');
+	if (slashedProtocol[urlObj.protocol]) {
+		urlObj.pathname = relative.replace(domain, '');
+	}
 
 	// IDN to Unicode
 	urlObj.hostname = punycode.toUnicode(urlObj.hostname).toLowerCase();

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var DEFAULT_PORTS = {
 	'ftp:': 21
 };
 // protocols that always contain a // bit.
-const slashedProtocol = {
+var slashedProtocol = {
 	'http': true,
 	'https': true,
 	'ftp': true,

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var DEFAULT_PORTS = {
 	'https:': 443,
 	'ftp:': 21
 };
+
 // protocols that always contain a // bit.
 var slashedProtocol = {
 	'http': true,

--- a/index.js
+++ b/index.js
@@ -63,10 +63,10 @@ module.exports = function (str, opts) {
 		urlObj.pathname = urlObj.pathname.replace(/\/{2,}/, '/');
 	}
 
-	// resolve relative paths
-	var domain = urlObj.protocol + '//' + urlObj.hostname;
-	var relative = url.resolve(domain, urlObj.pathname || '');
+	// resolve relative paths, but only for slashed protocols
 	if (slashedProtocol[urlObj.protocol]) {
+		var domain = urlObj.protocol + '//' + urlObj.hostname;
+		var relative = url.resolve(domain, urlObj.pathname);
 		urlObj.pathname = relative.replace(domain, '');
 	}
 

--- a/test.js
+++ b/test.js
@@ -25,6 +25,9 @@ test('main', t => {
 	t.is(fn('http://sindresorhus.com/foo#bar', {stripFragment: false}), 'http://sindresorhus.com/foo#bar');
 	t.is(fn('http://sindresorhus.com/foo/bar/../baz'), 'http://sindresorhus.com/foo/baz');
 	t.is(fn('http://sindresorhus.com/foo/bar/./baz'), 'http://sindresorhus.com/foo/bar/baz');
+	t.is(fn('sindre://www.sorhus.com'), 'sindre://sorhus.com');
+	t.is(fn('sindre://www.sorhus.com/'), 'sindre://sorhus.com');
+	t.is(fn('sindre://www.sorhus.com/foo/bar'), 'sindre://sorhus.com/foo/bar');
 	t.end();
 });
 
@@ -33,5 +36,6 @@ test('stripWWW option', t => {
 	t.is(fn('http://www.sindresorhus.com', opts), 'http://www.sindresorhus.com');
 	t.is(fn('www.sindresorhus.com', opts), 'http://www.sindresorhus.com');
 	t.is(fn('http://www.xn--xample-hva.com', opts), 'http://www.êxample.com');
+	t.is(fn('sindre://www.sorhus.com', opts), 'sindre://www.sorhus.com');
 	t.end();
 });


### PR DESCRIPTION
There is a difference in the handling of some url schemes in the resolve package. So only doing relative resolve if it's a slashed protocol in the url module.

Would probably need some special handling of some scheme as the normalization could be different. But this one will resolve them now and should support domains. Would maybe be better to remove the domain, but I'm not sure.

Should resolve #13 exception.