### PR TITLE
Decode &amp; in URLs when normalizing

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = function (str, opts) {
 	// prepend protocol
 	str = prependHttp(str.trim()).replace(/^\/\//, 'http://');
 
+	// decode query param separator
+	str = str.replace(/&amp;/g, '&');
+
 	var urlObj = url.parse(str);
 
 	// prevent these from being used by `url.format`

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ test('main', t => {
 	t.is(fn('www.sindresorhus.com'), 'http://sindresorhus.com');
 	t.is(fn('http://sindresorhus.com/foo/'), 'http://sindresorhus.com/foo');
 	t.is(fn('sindresorhus.com/?foo=bar%20baz'), 'http://sindresorhus.com/?foo=bar baz');
+	t.is(fn('sindresorhus.com/?foo=bar&amp;baz=baz'), 'http://sindresorhus.com/?baz=baz&foo=bar');
 	t.is(fn('http://sindresorhus.com/?'), 'http://sindresorhus.com');
 	t.is(fn('http://xn--xample-hva.com'), 'http://êxample.com');
 	t.is(fn('http://sindresorhus.com/?b=bar&a=foo'), 'http://sindresorhus.com/?a=foo&b=bar');

--- a/test.js
+++ b/test.js
@@ -25,7 +25,6 @@ test('main', t => {
 	t.is(fn('http://sindresorhus.com/foo#bar', {stripFragment: false}), 'http://sindresorhus.com/foo#bar');
 	t.is(fn('http://sindresorhus.com/foo/bar/../baz'), 'http://sindresorhus.com/foo/baz');
 	t.is(fn('http://sindresorhus.com/foo/bar/./baz'), 'http://sindresorhus.com/foo/bar/baz');
-	t.end();
 });
 
 test('stripWWW option', t => {
@@ -33,5 +32,4 @@ test('stripWWW option', t => {
 	t.is(fn('http://www.sindresorhus.com', opts), 'http://www.sindresorhus.com');
 	t.is(fn('www.sindresorhus.com', opts), 'http://www.sindresorhus.com');
 	t.is(fn('http://www.xn--xample-hva.com', opts), 'http://www.êxample.com');
-	t.end();
 });


### PR DESCRIPTION
When feeding URLs with querystrings straight from HTML to `normalize-url` the `&amp;` is not decoded which then outputs erroneous URLs.

Example

```
http://example.com?foo=bar&amp;bar=baz -> http://example.com?amp;bar=baz&foo=bar
```

When I think it instead should be:

```
http://example.com?foo=bar&amp;bar=baz -> http://example.com?bar=baz&foo=bar
```

Which is what this PR fixes. What do you think?