### PR TITLE
Fix exception thrown for domain-less URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,12 +53,14 @@ module.exports = function (str, opts) {
 	var relative = url.resolve(domain, urlObj.pathname);
 	urlObj.pathname = relative.replace(domain, '');
 
-	// IDN to Unicode
-	urlObj.hostname = punycode.toUnicode(urlObj.hostname).toLowerCase();
+	if (urlObj.hostname) {
+		// IDN to Unicode
+		urlObj.hostname = punycode.toUnicode(urlObj.hostname).toLowerCase();
 
-	// remove `www.`
-	if (opts.stripWWW) {
-		urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
+		// remove `www.`
+		if (opts.stripWWW) {
+			urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
+		}
 	}
 
 	// remove URL with empty query string

--- a/test.js
+++ b/test.js
@@ -25,6 +25,8 @@ test('main', t => {
 	t.is(fn('http://sindresorhus.com/foo#bar', {stripFragment: false}), 'http://sindresorhus.com/foo#bar');
 	t.is(fn('http://sindresorhus.com/foo/bar/../baz'), 'http://sindresorhus.com/foo/baz');
 	t.is(fn('http://sindresorhus.com/foo/bar/./baz'), 'http://sindresorhus.com/foo/bar/baz');
+	t.is(fn('/relative/path/'), '/relative/path');
+	t.is(fn('/'), '');
 });
 
 test('stripWWW option', t => {


### PR DESCRIPTION
`urlObj.hostname` can be `null` when called with URLs like "/foo".

This will cause the following exception to be thrown from punycode:
```
TypeError: Cannot read property 'split' of null
  at mapDomain (punycode.js:98:21)
  at Object.toUnicode (punycode.js:454:10)
```

This diff fixes that by checking that the hostname exists.