### PR TITLE
Add `removeTrailingSlash` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = function (str, opts) {
 	str = url.format(urlObj);
 
 	// remove ending `/`
-	if (opts.removeTrailingSlash) {
+	if (opts.removeTrailingSlash || !urlObj.pathname || urlObj.pathname === '/') {
 		str = str.replace(/\/$/, '');
 	}
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = function (str, opts) {
 	str = url.format(urlObj);
 
 	// remove ending `/`
-	if (opts.removeTrailingSlash || !urlObj.pathname || urlObj.pathname === '/') {
+	if (opts.removeTrailingSlash || urlObj.pathname === '/') {
 		str = str.replace(/\/$/, '');
 	}
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ module.exports = function (str, opts) {
 		normalizeProtocol: true,
 		stripFragment: true,
 		stripWWW: true,
-		removeQueryParameters: [/^utm_\w+/i]
+		removeQueryParameters: [/^utm_\w+/i],
+		removeTrailingSlash: true
 	}, opts);
 
 	if (typeof str !== 'string') {
@@ -121,7 +122,9 @@ module.exports = function (str, opts) {
 	str = url.format(urlObj);
 
 	// remove ending `/`
-	str = str.replace(/\/$/, '');
+	if (opts.removeTrailingSlash) {
+		str = str.replace(/\/$/, '');
+	}
 
 	// restore relative protocol, if applicable
 	if (hasRelativeProtocol && !opts.normalizeProtocol) {

--- a/readme.md
+++ b/readme.md
@@ -101,14 +101,18 @@ normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
 Type: `Boolean`<br>
 Default: `true`
 
-Remove trailing slash.
+Remove trailing slash.<br>
+**Note**: trailing slash is always removed if the url doesn't have a pathname.
 
 ```js
-normalizeUrl('http://sindresorhus.com/');
-//=> 'http://sindresorhus.com'
+normalizeUrl('http://sindresorhus.com/redirect/');
+//=> 'http://sindresorhus.com/redirect'
+
+normalizeUrl('http://sindresorhus.com/redirect/', {removeTrailingSlash: false});
+//=> 'http://sindresorhus.com/redirect/'
 
 normalizeUrl('http://sindresorhus.com/', {removeTrailingSlash: false});
-//=> 'http://sindresorhus.com/'
+//=> 'http://sindresorhus.com'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,20 @@ normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
 //=> 'http://sindresorhus.com/?foo=bar'
 ```
 
+##### removeTrailingSlash
+
+Type: `Boolean`<br>
+Default: `true`
+
+Remove trailing slash.
+
+```js
+normalizeUrl('http://sindresorhus.com/');
+//=> 'http://sindresorhus.com'
+
+normalizeUrl('http://sindresorhus.com/', {removeTrailingSlash: false});
+//=> 'http://sindresorhus.com/'
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,7 @@ Type: `Boolean`<br>
 Default: `true`
 
 Remove trailing slash.<br>
-**Note**: trailing slash is always removed if the url doesn't have a pathname.
+**Note:** trailing slash is always removed if the url doesn't have a pathname.
 
 ```js
 normalizeUrl('http://sindresorhus.com/redirect/');

--- a/test.js
+++ b/test.js
@@ -58,5 +58,8 @@ test('removeQueryParameters option', t => {
 test('removeTrailingSlash option', t => {
 	const opts = {removeTrailingSlash: false};
 	t.is(m('http://sindresorhus.com/'), 'http://sindresorhus.com');
-	t.is(m('http://sindresorhus.com/', opts), 'http://sindresorhus.com/');
+	t.is(m('http://sindresorhus.com/', opts), 'http://sindresorhus.com');
+
+	t.is(m('http://sindresorhus.com/redirect/'), 'http://sindresorhus.com/redirect');
+	t.is(m('http://sindresorhus.com/redirect/', opts), 'http://sindresorhus.com/redirect/');
 });

--- a/test.js
+++ b/test.js
@@ -59,7 +59,6 @@ test('removeTrailingSlash option', t => {
 	const opts = {removeTrailingSlash: false};
 	t.is(m('http://sindresorhus.com/'), 'http://sindresorhus.com');
 	t.is(m('http://sindresorhus.com/', opts), 'http://sindresorhus.com');
-
 	t.is(m('http://sindresorhus.com/redirect/'), 'http://sindresorhus.com/redirect');
 	t.is(m('http://sindresorhus.com/redirect/', opts), 'http://sindresorhus.com/redirect/');
 });

--- a/test.js
+++ b/test.js
@@ -54,3 +54,9 @@ test('removeQueryParameters option', t => {
 	t.is(m('www.sindresorhus.com?foo=bar', opts), 'http://www.sindresorhus.com/?foo=bar');
 	t.is(m('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', opts), 'http://www.sindresorhus.com/?foo=bar');
 });
+
+test('removeTrailingSlash option', t => {
+	const opts = {removeTrailingSlash: false};
+	t.is(m('http://sindresorhus.com/'), 'http://sindresorhus.com');
+	t.is(m('http://sindresorhus.com/', opts), 'http://sindresorhus.com/');
+});


### PR DESCRIPTION
Sometimes keeping trailing slashes is a necessity, e.g. in REST APIs.
This changelist adds the option `removeTrailingSlash`, with the default value `true` (thus, original operation and API is preserved).