### PR TITLE
fix readme: ignoredQueryParameters => removeQueryParameters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Remove query parameters that matches any of the provided strings or regexes.
 
 ```js
 normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
-	ignoredQueryParameters: ['ref']
+	removeQueryParameters: ['ref']
 });
 //=> 'http://sindresorhus.com/?foo=bar'
 ```


### PR DESCRIPTION
Hey

thanks for this great lib, i just stumbled across the `removeQueryParameters` attribute, which in the README example is wrongly named as `ignoredQueryParameters`.