### PR TITLE
remove multiple duplicate slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function (str, opts) {
 
 	// remove duplicate slashes
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/\/{2,}/, '/');
+		urlObj.pathname = urlObj.pathname.replace(/\/{2,}/g, '/');
 	}
 
 	// resolve relative paths, but only for slashed protocols

--- a/test.js
+++ b/test.js
@@ -20,6 +20,7 @@ test('main', t => {
 	t.is(m('http://sindresorhus.com/?foo=bar*|<>:"'), 'http://sindresorhus.com/?foo=bar*|<>:"');
 	t.is(m('http://sindresorhus.com:5000'), 'http://sindresorhus.com:5000');
 	t.is(m('http://sindresorhus.com////foo/bar'), 'http://sindresorhus.com/foo/bar');
+	t.is(m('http://sindresorhus.com////foo////bar'), 'http://sindresorhus.com/foo/bar');
 	t.is(m('//sindresorhus.com/', {normalizeProtocol: false}), '//sindresorhus.com');
 	t.is(m('//sindresorhus.com:80/', {normalizeProtocol: false}), '//sindresorhus.com');
 	t.is(m('http://sindresorhus.com/foo#bar'), 'http://sindresorhus.com/foo');


### PR DESCRIPTION
thanks for lib :)

This fix also fix the `removeTrailingSlash`, for example:
`http://abc.com///path///` => `http://abc.com/path//`
because the script only remove the last `one` slash