### PR TITLE
Fix bad interaction between removeTrailingSlash and removeDirectoryIndex options

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,9 +98,8 @@ module.exports = function (str, opts) {
 
 		if (testParameter(lastComponent, opts.removeDirectoryIndex)) {
 			pathComponents = pathComponents.slice(0, pathComponents.length - 1);
+			urlObj.pathname = pathComponents.slice(1).join('/') + '/';
 		}
-
-		urlObj.pathname = pathComponents.slice(1).join('/') + '/';
 	}
 
 	// resolve relative paths, but only for slashed protocols

--- a/test.js
+++ b/test.js
@@ -100,3 +100,19 @@ test('removeDirectoryIndex option', t => {
 	t.is(m('http://sindresorhus.com/index.htm', opts3), 'http://sindresorhus.com');
 	t.is(m('http://sindresorhus.com/index.php', opts3), 'http://sindresorhus.com');
 });
+
+test('removeTrailingSlash and removeDirectoryIndex options)', t => {
+	const opts1 = {
+		removeTrailingSlash: true,
+		removeDirectoryIndex: true
+	};
+	t.is(m('http://sindresorhus.com/path/', opts1), 'http://sindresorhus.com/path');
+	t.is(m('http://sindresorhus.com/path/index.html', opts1), 'http://sindresorhus.com/path');
+
+	const opts2 = {
+		removeTrailingSlash: false,
+		removeDirectoryIndex: true
+	};
+	t.is(m('http://sindresorhus.com/path/', opts2), 'http://sindresorhus.com/path/');
+	t.is(m('http://sindresorhus.com/path/index.html', opts2), 'http://sindresorhus.com/path/');
+});


### PR DESCRIPTION
Fixes #40. This should fix a problem in which the removeDirectoryIndex could cause an unwanted slash to be added to the end of a normalized URL.