### PR TITLE
Normalize encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,20 +139,16 @@ module.exports = (str, opts) => {
 	urlObj.search = queryString.stringify(sortKeys(queryParameters));
 
 	// Decode query parameters
-	urlObj.search = decodeURIComponent(urlObj.search);
+	const splitSearch = decodeURIComponent(urlObj.search).split('&');
 
 	// Find possible '&' characters inside parameter
-	const splitSearch = urlObj.search.split('&');
-
 	urlObj.search = splitSearch[0];
 
-	for (const param in splitSearch) {
-		if (param > 0) {
-			if (splitSearch[param].includes('=')) {
-				urlObj.search = urlObj.search + '&' + splitSearch[param];
-			} else {
-				urlObj.search = urlObj.search + '%26' + splitSearch[param];
-			}
+	for (let i = 1; i < splitSearch.length; i++) {
+		if (splitSearch[i].includes('=')) {
+			urlObj.search = urlObj.search + '&' + splitSearch[i];
+		} else {
+			urlObj.search = urlObj.search + '%26' + splitSearch[i];
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ module.exports = (str, opts) => {
 	urlObj.search = decodeURIComponent(urlObj.search);
 
 	// Take advantage of many of the Node `url` normalizations
-	str = url.format(urlObj);
+	str = decodeURIComponent(url.format(urlObj));
 
 	// Remove ending `/`
 	if (opts.removeTrailingSlash || urlObj.pathname === '/') {

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = (str, opts) => {
 
 	// Decode URI octets
 	if (urlObj.pathname) {
-		urlObj.pathname = decodeURI(urlObj.pathname);
+		urlObj.pathname = decodeURIComponent(urlObj.pathname);
 	}
 
 	// Remove directory index
@@ -141,8 +141,23 @@ module.exports = (str, opts) => {
 	// Decode query parameters
 	urlObj.search = decodeURIComponent(urlObj.search);
 
+	// Find possible '&' characters inside parameter
+	const splitSearch = urlObj.search.split('&');
+
+	urlObj.search = splitSearch[0];
+
+	for (const param in splitSearch) {
+		if (param > 0) {
+			if (splitSearch[param].includes('=')) {
+				urlObj.search = urlObj.search + '&' + splitSearch[param];
+			} else {
+				urlObj.search = urlObj.search + '%26' + splitSearch[param];
+			}
+		}
+	}
+
 	// Take advantage of many of the Node `url` normalizations
-	str = decodeURIComponent(url.format(urlObj));
+	str = url.format(urlObj);
 
 	// Remove ending `/`
 	if (opts.removeTrailingSlash || urlObj.pathname === '/') {

--- a/test.js
+++ b/test.js
@@ -26,6 +26,7 @@ test('main', t => {
 	t.is(m('//sindresorhus.com:80/', {normalizeProtocol: false}), '//sindresorhus.com');
 	t.is(m('file:///foo/node_modules/%40angular/http'), 'file:///foo/node_modules/@angular/http');
 	t.is(m('http://example.com/%40dave'), 'http://example.com/@dave');
+	t.is(m('http://host/?var1=va%26lue&var2=value'), 'http://host/?var1=va%26lue&var2=value');
 	t.is(m('http://sindresorhus.com/foo#bar'), 'http://sindresorhus.com/foo');
 	t.is(m('http://sindresorhus.com/foo#bar', {stripFragment: false}), 'http://sindresorhus.com/foo#bar');
 	t.is(m('http://sindresorhus.com/foo/bar/../baz'), 'http://sindresorhus.com/foo/baz');

--- a/test.js
+++ b/test.js
@@ -24,6 +24,8 @@ test('main', t => {
 	t.is(m('http://sindresorhus.com////foo////bar'), 'http://sindresorhus.com/foo/bar');
 	t.is(m('//sindresorhus.com/', {normalizeProtocol: false}), '//sindresorhus.com');
 	t.is(m('//sindresorhus.com:80/', {normalizeProtocol: false}), '//sindresorhus.com');
+	t.is(m('file:///foo/node_modules/%40angular/http'), 'file:///foo/node_modules/@angular/http');
+	t.is(m('http://example.com/%40dave'), 'http://example.com/@dave');
 	t.is(m('http://sindresorhus.com/foo#bar'), 'http://sindresorhus.com/foo');
 	t.is(m('http://sindresorhus.com/foo#bar', {stripFragment: false}), 'http://sindresorhus.com/foo#bar');
 	t.is(m('http://sindresorhus.com/foo/bar/../baz'), 'http://sindresorhus.com/foo/baz');


### PR DESCRIPTION
Fixes #43:
'@' symbol not being decoded from '%40'
used the decodeURIComponent() method. Maybe it's too general but, since the code still passes all previous tests, I suppose it's preferable to just replacing the '@' character with str.replace(/%40/, '@'), as it can prevent future similar issues.