### PR TITLE
Add a sortQueryParameters option

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ module.exports = (str, opts) => {
 		stripWWW: true,
 		removeQueryParameters: [/^utm_\w+/i],
 		removeTrailingSlash: true,
-		removeDirectoryIndex: false
+		removeDirectoryIndex: false,
+		sortQueryParameters: true
 	}, opts);
 
 	if (typeof str !== 'string') {
@@ -136,7 +137,9 @@ module.exports = (str, opts) => {
 	}
 
 	// Sort query parameters
-	urlObj.search = queryString.stringify(sortKeys(queryParameters));
+	if (opts.sortQueryParameters) {
+		urlObj.search = queryString.stringify(sortKeys(queryParameters));
+	}
 
 	// Decode query parameters
 	urlObj.search = decodeURIComponent(urlObj.search);

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,19 @@ normalizeUrl('www.sindresorhus.com/foo/default.php', {
 //=> 'http://sindresorhus.com/foo'
 ```
 
+##### sortQueryParameters
+
+Type: `boolean`<br>
+Default: `true`
+
+Sort the query parameters alphabetically by key.
+
+```js
+normalizeUrl('www.sindresorhus.com?b=two&a=one&c=three', {
+	sortQueryParameters: true
+});
+//=> 'www.sindresorhus.com?a=one&b=two&c=three'
+```
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -116,3 +116,20 @@ test('removeTrailingSlash and removeDirectoryIndex options)', t => {
 	t.is(m('http://sindresorhus.com/path/', opts2), 'http://sindresorhus.com/path/');
 	t.is(m('http://sindresorhus.com/path/index.html', opts2), 'http://sindresorhus.com/path/');
 });
+
+test('sortQueryParameters option', t => {
+	let opts = {
+		sortQueryParameters: true
+	};
+	t.is(m('http://sindresorhus.com/?a=Z&b=Y&c=X&d=W', opts), 'http://sindresorhus.com/?a=Z&b=Y&c=X&d=W');
+	t.is(m('http://sindresorhus.com/?b=Y&c=X&a=Z&d=W', opts), 'http://sindresorhus.com/?a=Z&b=Y&c=X&d=W');
+	t.is(m('http://sindresorhus.com/?a=Z&d=W&b=Y&c=X', opts), 'http://sindresorhus.com/?a=Z&b=Y&c=X&d=W');
+
+	opts = {
+		sortQueryParameters: false
+	};
+
+	t.is(m('http://sindresorhus.com/?a=Z&b=Y&c=X&d=W', opts), 'http://sindresorhus.com/?a=Z&b=Y&c=X&d=W');
+	t.is(m('http://sindresorhus.com/?b=Y&c=X&a=Z&d=W', opts), 'http://sindresorhus.com/?b=Y&c=X&a=Z&d=W');
+	t.is(m('http://sindresorhus.com/?a=Z&d=W&b=Y&c=X', opts), 'http://sindresorhus.com/?a=Z&d=W&b=Y&c=X');
+});


### PR DESCRIPTION
`normalize-url` sorts query parameters by default, but that's a normalization that changes semantics, and is breaking some of my uses cases.

Thus, this PR adds a new option, `sortQueryParameters`, which defaults to true, plus unit tests.