### PR TITLE
Patch for the Edge compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const testParameter = (name, filters) => {
 };
 
 module.exports = (urlString, options) => {
-	let paramOptions = options;
+	const paramOptions = options;
 	options = {
 		defaultProtocol: 'http:',
 		normalizeProtocol: true,

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const testParameter = (name, filters) => {
 };
 
 module.exports = (urlString, options) => {
+	let paramOptions = options;
 	options = {
 		defaultProtocol: 'http:',
 		normalizeProtocol: true,
@@ -18,9 +19,9 @@ module.exports = (urlString, options) => {
 		removeQueryParameters: [/^utm_\w+/i],
 		removeTrailingSlash: true,
 		removeDirectoryIndex: false,
-		sortQueryParameters: true,
-		...options
+		sortQueryParameters: true
 	};
+	options = Object.assign({}, options, paramOptions);
 
 	// TODO: Remove this at some point in the future
 	if (Reflect.has(options, 'normalizeHttps')) {


### PR DESCRIPTION
MS Edge does not support the triple dot notation.

This commit includes a workaround for this problem.
It adds the old JS way:
``` Javascript
Object.assign({},a,b);
```