### PR TITLE
Always strip www, not just for urls with one label

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = (urlString, options) => {
 		urlObj.hostname = urlObj.hostname.replace(/\.$/, '');
 
 		// Remove `www.`
-		if (options.stripWWW && /^www\.([a-z\-\d]{2,63})\.([a-z.]{2,5})$/.test(urlObj.hostname)) {
+		if (options.stripWWW && /^www(\.([a-z\-\d]{2,63}))+\.([a-z.]{2,5})$/.test(urlObj.hostname)) {
 			// Each label should be max 63 at length (min: 2).
 			// The extension should be max 5 at length (min: 2).
 			// Source: https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names


### PR DESCRIPTION
The current stripWWW regex only strips away the WWW label for urls with one label (e.g. it would not strip www.developers.google.com, only www.google.com). 