### PR TITLE
Add support for data URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@ module.exports = (urlString, options) => {
 
 	const urlObj = new URLParser(urlString);
 	
-	if (urlObj.protocol === 'data:') return urlString
+	if (urlObj.protocol === 'data:') {
+		return urlString;
+	}
 
 	if (options.forceHttp && options.forceHttps) {
 		throw new Error('The `forceHttp` and `forceHttps` options cannot be used together');

--- a/index.js
+++ b/index.js
@@ -46,6 +46,8 @@ module.exports = (urlString, options) => {
 	}
 
 	const urlObj = new URLParser(urlString);
+	
+	if (urlObj.protocol === 'data:') return urlString
 
 	if (options.forceHttp && options.forceHttps) {
 		throw new Error('The `forceHttp` and `forceHttps` options cannot be used together');


### PR DESCRIPTION
Not sure if you are interested in doing that on the library 🤔 

It allows support data URI, avoiding add prepend `http` and making the original URL invalid

```
require('normalize-url')('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7')
{ TypeError [ERR_INVALID_URL]: Invalid URL: http:data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
    at onParseError (internal/url.js:241:17)
    at new URL (internal/url.js:319:5)
    at module.exports (/Users/josefranciscoverdugambin/Projects/microlink/metascraper/packages/metascraper-helpers/node_modules/normalize-url/index.js:48:17)
  input:
   'http:data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7' }
```