### PR TITLE
Add `removeAllQueryParameters` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,7 @@ export interface Options {
 	readonly stripWWW?: boolean;
 
 	/**
-	 * Removes All query parameters.
+	 * Removes all query parameters.
 	 *
 	 * @default false
 	 *

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,20 @@ export interface Options {
 	readonly stripWWW?: boolean;
 
 	/**
+	 * Removes All query parameters.
+	 *
+	 * @default false
+	 *
+	 * @example
+	 *
+	 * normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
+	 * 	removeAllQueryParameters: true
+	 * });
+	 * //=> 'http://sindresorhus.com'
+	 */
+	readonly removeAllQueryParameters?: boolean;
+
+	/**
 	 * Removes query parameters that matches any of the provided strings or regexes.
 	 *
 	 * @default [/^utm_\w+/i]

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const normalizeUrl = (urlString, options) => {
 		stripHash: false,
 		stripWWW: true,
 		removeQueryParameters: [/^utm_\w+/i],
+		removeAllQueryParameters: false,
 		removeTrailingSlash: true,
 		removeDirectoryIndex: false,
 		sortQueryParameters: true,
@@ -113,6 +114,13 @@ const normalizeUrl = (urlString, options) => {
 			// The extension should be max 5 at length (min: 2).
 			// Source: https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
 			urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
+		}
+	}
+
+	// Remove all query parameters
+	if (options.removeAllQueryParameters) {
+		for (const key of urlObj.searchParams.keys()) {
+			urlObj.searchParams.delete(key);
 		}
 	}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,6 +12,7 @@ normalizeUrl('user:password@sindresorhus.com', {stripAuthentication: false});
 normalizeUrl('sindresorhus.com/about.html#contact', {stripHash: true});
 normalizeUrl('https://sindresorhus.com', {stripProtocol: true});
 normalizeUrl('http://www.sindresorhus.com', {stripWWW: false});
+normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {removeAllQueryParameters: true});
 normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
 	removeQueryParameters: ['ref', /test/]
 });

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,20 @@ normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
 //=> 'http://sindresorhus.com/?foo=bar'
 ```
 
+##### removeAllQueryParameters
+
+Type: `boolean`<br>
+Default: `false`
+
+Removes all query parameters.
+
+```js
+normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
+	removeAllQueryParameters: true
+});
+//=> 'http://sindresorhus.com'
+```
+
 ##### removeTrailingSlash
 
 Type: `boolean`<br>

--- a/test.js
+++ b/test.js
@@ -75,6 +75,17 @@ test('stripWWW option', t => {
 	t.is(normalizeUrl('sindre://www.sorhus.com', options), 'sindre://www.sorhus.com');
 });
 
+test('removeAllQueryParameters option', t => {
+	const options = {
+		stripWWW: false,
+		removeAllQueryParameters: true
+	};
+	t.is(normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test', options), 'http://www.sindresorhus.com');
+	t.is(normalizeUrl('http://www.sindresorhus.com', options), 'http://www.sindresorhus.com');
+	t.is(normalizeUrl('www.sindresorhus.com?foo=bar', options), 'http://www.sindresorhus.com');
+	t.is(normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', options), 'http://www.sindresorhus.com');
+});
+
 test('removeQueryParameters option', t => {
 	const options = {
 		stripWWW: false,


### PR DESCRIPTION
I think this is useful. Sometimes when normalizing URLs, all parameters need to be removed.