### PR TITLE
Don't use object-rest-spread

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const testParameter = (name, filters) => {
 };
 
 const normalizeUrl = (urlString, options) => {
-	options = {
+	options = Object.assign({
 		defaultProtocol: 'http:',
 		normalizeProtocol: true,
 		forceHttp: false,
@@ -19,8 +19,7 @@ const normalizeUrl = (urlString, options) => {
 		removeTrailingSlash: true,
 		removeDirectoryIndex: false,
 		sortQueryParameters: true,
-		...options
-	};
+	}, options);
 
 	// TODO: Remove this at some point in the future
 	if (Reflect.has(options, 'normalizeHttps')) {


### PR DESCRIPTION
https://github.com/tc39/proposal-object-rest-spread

This syntax was only added in 2018. As such it doesn't work in MS Edge.
I depend on normalize-url by way of metascraper. My application was broken in MS Edge because of this.

There is a workaround when using webpack by having it use babel-loader to transpile to es6. But it adds to the configuration complexity and build time. My project has a ton of dependencies, and normalize-url is the only one that requires transpilation to work in MS Edge (probably many use object rest spread too, but transpile to es6 or es5 before `npm push`). https://medium.com/@jeffrey.allen.lewis/the-ultimate-2018-webpack-4-and-babel-setup-guide-npm-yarn-dependencies-compared-entry-points-866b577da6a

If the code here is what a lot less readable without using object-rest-spread, I would understand why you might not want this PR. But since it's only one place, and each of your dependees might have to spend a couple hours debugging and setting up babel-loader, I figured you might merge to make your users' lives easier.

<3