### PR TITLE
Advertise correct package.json engine of node 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=8.3.0"
 	},
 	"scripts": {
 		"test": "xo && nyc ava && tsd-check"


### PR DESCRIPTION
I think you're unnecessarily limiting the utility of the library by closing #90, and I acknowledge that's your prerogative. This PR at least fixes the false advertisement of the >=8.0 engine in package.json.