### PR TITLE
Add data URL support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,7 +192,7 @@ declare const normalizeUrl: {
 	/**
 	[Normalize](https://en.wikipedia.org/wiki/URL_normalization) a URL.
 
-	@param url - URL(including data URLs) to normalize.
+	@param url - URL to normalize, including [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -192,7 +192,7 @@ declare const normalizeUrl: {
 	/**
 	[Normalize](https://en.wikipedia.org/wiki/URL_normalization) a URL.
 
-	@param url - URL to normalize.
+	@param url - URL(including data URLs) to normalize.
 
 	@example
 	```

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ const normalizeUrl = (urlString, options) => {
 		urlObj.searchParams.sort();
 	}
 
-	// DataUrls
+	// Data URL
 	if (urlObj.protocol === 'data:') {
 		const url = normalizeDataURL(`${urlObj.protocol}${urlObj.pathname}`);
 		return `${url}${urlObj.search}${urlObj.hash}`;

--- a/index.js
+++ b/index.js
@@ -25,11 +25,10 @@ const parseDataURL = urlString => {
 		const [contentType, ...attributes] = mimeType.split(';');
 		// TODO: Use `Object.fromEntries` when targeting Node.js 10
 		// Object.assign(parsed, Object.fromEntries(attributes.map(attribute => attribute.split('='))))
-		attributes.reduce((parsed, attribute) => {
+		for (const attribute of attributes) {
 			const [key, value] = attribute.split('=');
 			parsed[key] = value;
-			return parsed;
-		}, parsed);
+		}
 
 		parsed.mimeType = mimeType;
 		parsed.contentType = contentType;

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ const normalizeUrl = (urlString, options) => {
 	const isRelativeUrl = !hasRelativeProtocol && /^\.*\//.test(urlString);
 
 	// Prepend protocol
-	if (!isRelativeUrl && !/^data?:/i.test(urlString)) {
+	if (!isRelativeUrl && !/^data:/i.test(urlString)) {
 		urlString = urlString.replace(/^(?!(?:\w+:)?\/\/)|^\/\//, options.defaultProtocol);
 	}
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,50 @@ const testParameter = (name, filters) => {
 	return filters.some(filter => filter instanceof RegExp ? filter.test(name) : filter === name);
 };
 
+// from https://github.com/killmenot/valid-data-url/blob/8d56cab866469a4608001f0e8c5d73f65789ba13/index.js#L24
+const dataURLRegex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
+
+const isValidDataURL = urlString => {
+  return dataURLRegex.test(urlString)
+}
+
+const parseDataURL = urlString => {
+	if (!isValidDataURL(urlString)) {
+		throw new Error(`Invalid URL: ${urlString}`);
+	}
+
+  const parts = urlString.trim().match(dataURLRegex);
+  const parsed = {};
+
+  if (parts[1]) {
+		const mimeType = parts[1].toLowerCase();
+    const [contentType, ...attributes] = mimeType.split(';');
+		// TODO: use `Object.fromEntries`
+		// Object.assign(parsed, Object.fromEntries(attributes.map(attribute => attribute.split('='))))
+		attributes.reduce((parsed, attribute) => {
+			const [key, value] = attribute.split('=')
+			parsed[key] = value
+			return parsed;
+		}, parsed);
+
+		parsed.mimeType = mimeType;
+    parsed.contentType = contentType;
+  }
+
+  parsed.base64 = !!parts[parts.length - 2];
+  parsed.body = parts[parts.length - 1] || '';
+
+  return parsed;
+};
+
+const normalizeDataURL = urlString => {
+	const data = parseDataURL(urlString);
+
+	const body = data.base64 ? data.body.trim() : data.body
+
+	return `data:${data.mimeType}${data.base64 ? ';base64' : ''},${body}`
+}
+
 const normalizeUrl = (urlString, options) => {
 	options = {
 		defaultProtocol: 'http:',
@@ -41,7 +85,7 @@ const normalizeUrl = (urlString, options) => {
 	const isRelativeUrl = !hasRelativeProtocol && /^\.*\//.test(urlString);
 
 	// Prepend protocol
-	if (!isRelativeUrl) {
+	if (!isRelativeUrl && !/^data?:/i.test(urlString)) {
 		urlString = urlString.replace(/^(?!(?:\w+:)?\/\/)|^\/\//, options.defaultProtocol);
 	}
 
@@ -150,6 +194,11 @@ const normalizeUrl = (urlString, options) => {
 	// Remove http/https
 	if (options.stripProtocol) {
 		urlString = urlString.replace(/^(?:https?:)?\/\//, '');
+	}
+
+	if (urlObj.protocol === 'data:') {
+		const url = normalizeDataURL(`${urlObj.protocol}${urlObj.pathname}`)
+		return `${url}${urlObj.search}${urlObj.hash}`
 	}
 
 	return urlString;

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const normalizeDataURL = urlString => {
 	const attributes = mediaType
 		.filter(Boolean)
 		.map(attribute => {
-			let [key, value] = attribute.split('=').map(string => string.trim());
+			let [key, value = ''] = attribute.split('=').map(string => string.trim());
 
 			// Lowercase `charset`
 			if (key === 'charset') {

--- a/index.js
+++ b/index.js
@@ -10,9 +10,7 @@ const testParameter = (name, filters) => {
 // eslint-disable-next-line no-useless-escape
 const dataURLRegex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
 
-const isValidDataURL = urlString => {
-	return dataURLRegex.test(urlString);
-};
+const isValidDataURL = urlString => dataURLRegex.test(urlString);
 
 const parseDataURL = urlString => {
 	if (!isValidDataURL(urlString)) {
@@ -25,7 +23,7 @@ const parseDataURL = urlString => {
 	if (parts[1]) {
 		const mimeType = parts[1].toLowerCase();
 		const [contentType, ...attributes] = mimeType.split(';');
-		// TODO: use `Object.fromEntries`
+		// TODO: Use `Object.fromEntries` when targeting Node.js 10
 		// Object.assign(parsed, Object.fromEntries(attributes.map(attribute => attribute.split('='))))
 		attributes.reduce((parsed, attribute) => {
 			const [key, value] = attribute.split('=');
@@ -45,10 +43,8 @@ const parseDataURL = urlString => {
 
 const normalizeDataURL = urlString => {
 	const data = parseDataURL(urlString);
-
 	const body = data.base64 ? data.body.trim() : data.body;
 	const {mimeType = ''} = data;
-
 	return `data:${mimeType}${data.base64 ? ';base64' : ''},${body}`;
 };
 

--- a/index.js
+++ b/index.js
@@ -175,6 +175,12 @@ const normalizeUrl = (urlString, options) => {
 		urlObj.searchParams.sort();
 	}
 
+	// DataUrls
+	if (urlObj.protocol === 'data:') {
+		const url = normalizeDataURL(`${urlObj.protocol}${urlObj.pathname}`);
+		return `${url}${urlObj.search}${urlObj.hash}`;
+	}
+
 	if (options.removeTrailingSlash) {
 		urlObj.pathname = urlObj.pathname.replace(/\/$/, '');
 	}
@@ -195,11 +201,6 @@ const normalizeUrl = (urlString, options) => {
 	// Remove http/https
 	if (options.stripProtocol) {
 		urlString = urlString.replace(/^(?:https?:)?\/\//, '');
-	}
-
-	if (urlObj.protocol === 'data:') {
-		const url = normalizeDataURL(`${urlObj.protocol}${urlObj.pathname}`);
-		return `${url}${urlObj.search}${urlObj.hash}`;
 	}
 
 	return urlString;

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const normalizeDataURL = urlString => {
 	const data = parseDataURL(urlString);
 
 	const body = data.base64 ? data.body.trim() : data.body;
-	const {mimeType = ''} = data
+	const {mimeType = ''} = data;
 
 	return `data:${mimeType}${data.base64 ? ';base64' : ''},${body}`;
 };

--- a/index.js
+++ b/index.js
@@ -39,9 +39,12 @@ const normalizeDataURL = urlString => {
 		});
 
 	const normalizedMediaType = [
-		...attributes,
-		base64 ? 'base64' : ''
-	].filter(Boolean);
+		...attributes
+	];
+
+	if (base64) {
+		normalizedMediaType.push('base64');
+	}
 
 	if (normalizedMediaType.length !== 0 || mimeType) {
 		normalizedMediaType.unshift(mimeType);

--- a/index.js
+++ b/index.js
@@ -47,8 +47,9 @@ const normalizeDataURL = urlString => {
 	const data = parseDataURL(urlString);
 
 	const body = data.base64 ? data.body.trim() : data.body;
+	const {mimeType = ''} = data
 
-	return `data:${data.mimeType}${data.base64 ? ';base64' : ''},${body}`;
+	return `data:${mimeType}${data.base64 ? ';base64' : ''},${body}`;
 };
 
 const normalizeUrl = (urlString, options) => {

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const testParameter = (name, filters) => {
 	return filters.some(filter => filter instanceof RegExp ? filter.test(name) : filter === name);
 };
 
-// From https://github.com/killmenot/valid-data-url/blob/8d56cab866469a4608001f0e8c5d73f65789ba13/index.js#L24
-// eslint-disable-next-line no-useless-escape
-const dataURLRegex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
+// Based on valid-data-url
+// https://github.com/killmenot/valid-data-url/blob/8d56cab866469a4608001f0e8c5d73f65789ba13/index.js#L24
+const dataURLRegex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@/?%\s]*?)$/i;
 
 const isValidDataURL = urlString => dataURLRegex.test(urlString);
 

--- a/index.js
+++ b/index.js
@@ -6,49 +6,50 @@ const testParameter = (name, filters) => {
 	return filters.some(filter => filter instanceof RegExp ? filter.test(name) : filter === name);
 };
 
-// from https://github.com/killmenot/valid-data-url/blob/8d56cab866469a4608001f0e8c5d73f65789ba13/index.js#L24
+// From https://github.com/killmenot/valid-data-url/blob/8d56cab866469a4608001f0e8c5d73f65789ba13/index.js#L24
+// eslint-disable-next-line no-useless-escape
 const dataURLRegex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
 
 const isValidDataURL = urlString => {
-  return dataURLRegex.test(urlString)
-}
+	return dataURLRegex.test(urlString);
+};
 
 const parseDataURL = urlString => {
 	if (!isValidDataURL(urlString)) {
 		throw new Error(`Invalid URL: ${urlString}`);
 	}
 
-  const parts = urlString.trim().match(dataURLRegex);
-  const parsed = {};
+	const parts = urlString.trim().match(dataURLRegex);
+	const parsed = {};
 
-  if (parts[1]) {
+	if (parts[1]) {
 		const mimeType = parts[1].toLowerCase();
-    const [contentType, ...attributes] = mimeType.split(';');
+		const [contentType, ...attributes] = mimeType.split(';');
 		// TODO: use `Object.fromEntries`
 		// Object.assign(parsed, Object.fromEntries(attributes.map(attribute => attribute.split('='))))
 		attributes.reduce((parsed, attribute) => {
-			const [key, value] = attribute.split('=')
-			parsed[key] = value
+			const [key, value] = attribute.split('=');
+			parsed[key] = value;
 			return parsed;
 		}, parsed);
 
 		parsed.mimeType = mimeType;
-    parsed.contentType = contentType;
-  }
+		parsed.contentType = contentType;
+	}
 
-  parsed.base64 = !!parts[parts.length - 2];
-  parsed.body = parts[parts.length - 1] || '';
+	parsed.base64 = Boolean(parts[parts.length - 2]);
+	parsed.body = parts[parts.length - 1] || '';
 
-  return parsed;
+	return parsed;
 };
 
 const normalizeDataURL = urlString => {
 	const data = parseDataURL(urlString);
 
-	const body = data.base64 ? data.body.trim() : data.body
+	const body = data.base64 ? data.body.trim() : data.body;
 
-	return `data:${data.mimeType}${data.base64 ? ';base64' : ''},${body}`
-}
+	return `data:${data.mimeType}${data.base64 ? ';base64' : ''},${body}`;
+};
 
 const normalizeUrl = (urlString, options) => {
 	options = {
@@ -197,8 +198,8 @@ const normalizeUrl = (urlString, options) => {
 	}
 
 	if (urlObj.protocol === 'data:') {
-		const url = normalizeDataURL(`${urlObj.protocol}${urlObj.pathname}`)
-		return `${url}${urlObj.search}${urlObj.hash}`
+		const url = normalizeDataURL(`${urlObj.protocol}${urlObj.pathname}`);
+		return `${url}${urlObj.search}${urlObj.hash}`;
 	}
 
 	return urlString;

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ normalizeUrl('HTTP://xn--xample-hva.com:80/?b=bar&a=foo');
 
 Type: `string`
 
-URL to normalize.
+URL(including data URLs) to normalize.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ normalizeUrl('HTTP://xn--xample-hva.com:80/?b=bar&a=foo');
 
 Type: `string`
 
-URL(including data URLs) to normalize.
+URL to normalize, including [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -209,6 +209,8 @@ test('DataURLs', t => {
 	t.throws(() => {
 		normalizeUrl('data:text/plain;charset=UTF-8;,foo');
 	}, 'Invalid URL: data:text/plain;charset=UTF-8;,foo');
+	// Empty mimeType
+	t.is(normalizeUrl('data:,'), 'data:,');
 	// Lowercase the mimeType
 	t.is(normalizeUrl('data:TEXT/plain;charset=UTF-8,foo'), 'data:text/plain;charset=utf-8,foo');
 	// Remove spaces after the comma when it's base64

--- a/test.js
+++ b/test.js
@@ -205,21 +205,27 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com//foo'), 'http://sindresorhus.com/foo');
 });
 
-test('DataURLs', t => {
+test('data URL', t => {
 	t.throws(() => {
 		normalizeUrl('data:text/plain;charset=UTF-8;,foo');
 	}, 'Invalid URL: data:text/plain;charset=UTF-8;,foo');
-	// Empty mimeType
+
+	// Empty MIME type.
 	t.is(normalizeUrl('data:,'), 'data:,');
-	// Lowercase the mimeType
+
+	// Lowercase the MIME type.
 	t.is(normalizeUrl('data:TEXT/plain;charset=UTF-8,foo'), 'data:text/plain;charset=utf-8,foo');
-	// Remove spaces after the comma when it's base64
+
+	// Remove spaces after the comma when it's base64.
 	t.is(normalizeUrl('data:image/gif;base64, R0lGODlhAQABAAAAACw= ?foo=bar'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar');
-	// Keep spaces when it's not base64
+
+	// Keep spaces when it's not base64.
 	t.is(normalizeUrl('data:text/plain;charset=utf-8, foo ?foo=bar'), 'data:text/plain;charset=utf-8, foo?foo=bar');
-	// DataURL with query and hash
+
+	// Data URL with query and hash.
 	t.is(normalizeUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz');
-	// Options
+
+	// Options.
 	t.is(normalizeUrl('data:text/plain;charset=utf-8,www.foo/index.html?foo=bar&a=a&utm_medium=test#baz', {
 		defaultProtocol: 'http:',
 		normalizeProtocol: true,

--- a/test.js
+++ b/test.js
@@ -206,15 +206,23 @@ test('remove duplicate pathname slashes', t => {
 });
 
 test('data URL', t => {
-	t.throws(() => {
-		normalizeUrl('data:text/plain;charset=UTF-8;,foo');
-	}, 'Invalid URL: data:text/plain;charset=UTF-8;,foo');
+	// Invalid URL.
+	t.throws(() => normalizeUrl('data:'), 'Invalid URL: data:');
+
+	// Normalize away trailing semicolon.
+	t.is(normalizeUrl('data:text/plain;charset=UTF-8;,foo'), 'data:text/plain;charset=utf-8,foo');
 
 	// Empty MIME type.
 	t.is(normalizeUrl('data:,'), 'data:,');
 
+	// Empty MIME type with charset.
+	t.is(normalizeUrl('data:;charset=utf-8,foo'), 'data:;charset=utf-8,foo');
+
 	// Lowercase the MIME type.
-	t.is(normalizeUrl('data:TEXT/plain;charset=UTF-8,foo'), 'data:text/plain;charset=utf-8,foo');
+	t.is(normalizeUrl('data:TEXT/plain,foo'), 'data:text/plain,foo');
+
+	// Lowercase the charset.
+	t.is(normalizeUrl('data:text/plain;charset=UTF-8,foo'), 'data:text/plain;charset=utf-8,foo');
 
 	// Remove spaces after the comma when it's base64.
 	t.is(normalizeUrl('data:image/gif;base64, R0lGODlhAQABAAAAACw= ?foo=bar'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar');

--- a/test.js
+++ b/test.js
@@ -215,11 +215,11 @@ test('DataURLs', t => {
 	t.is(normalizeUrl('data:image/gif;base64, R0lGODlhAQABAAAAACw= ?foo=bar'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar');
 	// Keep spaces when it's not base64
 	t.is(normalizeUrl('data:text/plain;charset=utf-8, foo ?foo=bar'), 'data:text/plain;charset=utf-8, foo?foo=bar');
-	// with query and hash
+	// DataURL with query and hash
 	t.is(normalizeUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz');
-	// removeQueryParameters & stripHash
+	// Options: removeQueryParameters & stripHash
 	t.is(normalizeUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar&utm_medium=test#baz', {
 		removeQueryParameters: [/^utm_\w+/i, 'ref'],
 		stripHash: true
 	}), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar');
-})
+});

--- a/test.js
+++ b/test.js
@@ -217,9 +217,17 @@ test('DataURLs', t => {
 	t.is(normalizeUrl('data:text/plain;charset=utf-8, foo ?foo=bar'), 'data:text/plain;charset=utf-8, foo?foo=bar');
 	// DataURL with query and hash
 	t.is(normalizeUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz');
-	// Options: removeQueryParameters & stripHash
-	t.is(normalizeUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar&utm_medium=test#baz', {
+	// Options
+	t.is(normalizeUrl('data:text/plain;charset=utf-8,www.foo/index.html?foo=bar&a=a&utm_medium=test#baz', {
+		defaultProtocol: 'http:',
+		normalizeProtocol: true,
+		forceHttp: true,
+		stripHash: true,
+		stripWWW: true,
+		stripProtocol: true,
 		removeQueryParameters: [/^utm_\w+/i, 'ref'],
-		stripHash: true
-	}), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar');
+		sortQueryParameters: true,
+		removeTrailingSlash: true,
+		removeDirectoryIndex: true
+	}), 'data:text/plain;charset=utf-8,www.foo/index.html?a=a&foo=bar');
 });

--- a/test.js
+++ b/test.js
@@ -204,3 +204,22 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com:5000//foo'), 'http://sindresorhus.com:5000/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo'), 'http://sindresorhus.com/foo');
 });
+
+test('DataURLs', t => {
+	t.throws(() => {
+		normalizeUrl('data:text/plain;charset=UTF-8;,foo');
+	}, 'Invalid URL: data:text/plain;charset=UTF-8;,foo');
+	// Lowercase the mimeType
+	t.is(normalizeUrl('data:TEXT/plain;charset=UTF-8,foo'), 'data:text/plain;charset=utf-8,foo');
+	// Remove spaces after the comma when it's base64
+	t.is(normalizeUrl('data:image/gif;base64, R0lGODlhAQABAAAAACw= ?foo=bar'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar');
+	// Keep spaces when it's not base64
+	t.is(normalizeUrl('data:text/plain;charset=utf-8, foo ?foo=bar'), 'data:text/plain;charset=utf-8, foo?foo=bar');
+	// with query and hash
+	t.is(normalizeUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar#baz');
+	// removeQueryParameters & stripHash
+	t.is(normalizeUrl('data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar&utm_medium=test#baz', {
+		removeQueryParameters: [/^utm_\w+/i, 'ref'],
+		stripHash: true
+	}), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=?foo=bar');
+})


### PR DESCRIPTION
fixes: #94  & #84 

questions:

1. url `data:text/plain;charset=UTF-8;,foo` mentioned in #84, is not valid url accounding to `valid-data-url`, should I change Regex to loose strict one?
2. any more test cases need cover?
3. are we going to support other protocols like `file:` `ftp:` etc


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#94: Normalize data URLs](https://issuehunt.io/repos/29094022/issues/94)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->