### PR TITLE
Allow any protocol in the duplicate slashes normalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/(?<![a-z0-9]{2,}:)\/{2,}/g, '/');
+		urlObj.pathname = urlObj.pathname.replace(/(?<![a-z\d]{2,}:)\/{2,}/g, '/');
 	}
 
 	// Decode URI octets

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/(?<!(?:[a-z0-9]{2,}):)\/{2,}/g, '/');
+		urlObj.pathname = urlObj.pathname.replace(/(?<![a-z0-9]{2,}:)\/{2,}/g, '/');
 	}
 
 	// Decode URI octets

--- a/index.js
+++ b/index.js
@@ -72,8 +72,6 @@ const normalizeUrl = (urlString, options) => {
 		removeTrailingSlash: true,
 		removeDirectoryIndex: false,
 		sortQueryParameters: true,
-		embeddedProtocolMinLength: 2,
-		embeddedProtocolMaxLength: 50,
 		...options
 	};
 
@@ -98,14 +96,6 @@ const normalizeUrl = (urlString, options) => {
 		throw new Error('The `forceHttp` and `forceHttps` options cannot be used together');
 	}
 
-	if (options.embeddedProtocolMinLength < 1) {
-		throw new Error('The `embeddedProtocolMinLength` option must be greater than 0');
-	}
-
-	if (options.embeddedProtocolMaxLength < options.embeddedProtocolMinLength) {
-		throw new Error('The `embeddedProtocolMaxLength` option cannot be less than the `embeddedProtocolMinLength`');
-	}
-
 	if (options.forceHttp && urlObj.protocol === 'https:') {
 		urlObj.protocol = 'http:';
 	}
@@ -127,8 +117,7 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		const regex = new RegExp(`(?:(?<=[a-z\\d]{${options.embeddedProtocolMaxLength + 1},}:)|(?<![a-z\\d]{${options.embeddedProtocolMinLength},}:))\\/{2,}`, 'gi');
-		urlObj.pathname = urlObj.pathname.replace(regex, '/');
+		urlObj.pathname = urlObj.pathname.replace(/(?:(?<=[a-z\d]{31,}:)|(?<![a-z\d]{2,}:))\/{2,}/g, '/');
 	}
 
 	// Decode URI octets

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/(?:(?<=[a-z\d]{31,}:)|(?<![a-z\d]{2,}:))\/{2,}/g, '/');
+		urlObj.pathname = urlObj.pathname.replace(/(?:(?<=[a-z\d]{51,}:)|(?<![a-z\d]{2,}:))\/{2,}/g, '/');
 	}
 
 	// Decode URI octets

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/(?<!https?:)\/{2,}/g, '/');
+		urlObj.pathname = urlObj.pathname.replace(/(?<!(?:[a-z0-9]{2,}):)\/{2,}/g, '/');
 	}
 
 	// Decode URI octets

--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ const normalizeUrl = (urlString, options) => {
 		removeTrailingSlash: true,
 		removeDirectoryIndex: false,
 		sortQueryParameters: true,
+		embeddedProtocolMinLength: 2,
+		embeddedProtocolMaxLength: 50,
 		...options
 	};
 
@@ -96,6 +98,14 @@ const normalizeUrl = (urlString, options) => {
 		throw new Error('The `forceHttp` and `forceHttps` options cannot be used together');
 	}
 
+	if (options.embeddedProtocolMinLength < 1) {
+		throw new Error('The `embeddedProtocolMinLength` option must be greater than 0');
+	}
+
+	if (options.embeddedProtocolMaxLength < options.embeddedProtocolMinLength) {
+		throw new Error('The `embeddedProtocolMaxLength` option cannot be less than the `embeddedProtocolMinLength`');
+	}
+
 	if (options.forceHttp && urlObj.protocol === 'https:') {
 		urlObj.protocol = 'http:';
 	}
@@ -117,7 +127,8 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/(?:(?<=[a-z\d]{31,}:)|(?<![a-z\d]{2,}:))\/{2,}/g, '/');
+		const regex = new RegExp(`(?:(?<=[a-z\\d]{${options.embeddedProtocolMaxLength + 1},}:)|(?<![a-z\\d]{${options.embeddedProtocolMinLength},}:))\\/{2,}`, 'gi');
+		urlObj.pathname = urlObj.pathname.replace(regex, '/');
 	}
 
 	// Decode URI octets

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/(?<![a-z\d]{2,}:)\/{2,}/g, '/');
+		urlObj.pathname = urlObj.pathname.replace(/(?:(?<=[a-z\d]{31,}:)|(?<![a-z\d]{2,}:))\/{2,}/g, '/');
 	}
 
 	// Decode URI octets

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const normalizeUrl = (urlString, options) => {
 
 	// Remove duplicate slashes if not preceded by a protocol
 	if (urlObj.pathname) {
-		urlObj.pathname = urlObj.pathname.replace(/(?:(?<=[a-z\d]{51,}:)|(?<![a-z\d]{2,}:))\/{2,}/g, '/');
+		urlObj.pathname = urlObj.pathname.replace(/(?<!\b(?:[a-z][a-z\d+\-.]{1,50}:))\/{2,}/g, '/');
 	}
 
 	// Decode URI octets

--- a/readme.md
+++ b/readme.md
@@ -212,37 +212,6 @@ normalizeUrl('www.sindresorhus.com?b=two&a=one&c=three', {
 //=> 'http://sindresorhus.com/?b=two&a=one&c=three'
 ```
 
-##### embeddedProtocolMinLength
-
-Type: `number`\
-Default: `2`
-
-Duplicate slashes will be removed unless prefixed by a protocol with length greater than or equal to `embeddedProtocolMinLength` and less than or equal to `embeddedProtocolMaxLength`.
-
-**Note:** Must be at least 1.
-
-```js
-normalizeUrl('www.sindresorhus.com//foo/bar://sindresorhus.com/ab://b.com', {
-	embeddedProtocolMinLength: 3
-});
-//=> 'www.sindresorhus.com/foo/bar://sindresorhus.com/ab:/b.com'
-```
-
-##### embeddedProtocolMaxLength
-
-Type: `number`\
-Default: `50`
-
-**Note:** Cannot be less than `embeddedProtocolMinLength`.
-
-Duplicate slashes will be removed unless prefixed by a protocol with length greater than or equal to `embeddedProtocolMinLength` and less than or equal to `embeddedProtocolMaxLength`
-```js
-normalizeUrl('www.sindresorhus.com//foo/bar://sindresorhus.com/abcdef://b.com', {
-	embeddedProtocolMaxLength: 5
-});
-//=> 'www.sindresorhus.com/foo/bar://sindresorhus.com/abcdef:/b.com'
-```
-
 ## Related
 
 - [compare-urls](https://github.com/sindresorhus/compare-urls) - Compare URLs by first normalizing them

--- a/readme.md
+++ b/readme.md
@@ -212,6 +212,37 @@ normalizeUrl('www.sindresorhus.com?b=two&a=one&c=three', {
 //=> 'http://sindresorhus.com/?b=two&a=one&c=three'
 ```
 
+##### embeddedProtocolMinLength
+
+Type: `number`\
+Default: `2`
+
+Duplicate slashes will be removed unless prefixed by a protocol with length greater than or equal to `embeddedProtocolMinLength` and less than or equal to `embeddedProtocolMaxLength`.
+
+**Note:** Must be at least 1.
+
+```js
+normalizeUrl('www.sindresorhus.com//foo/bar://sindresorhus.com/ab://b.com', {
+	embeddedProtocolMinLength: 3
+});
+//=> 'www.sindresorhus.com/foo/bar://sindresorhus.com/ab:/b.com'
+```
+
+##### embeddedProtocolMaxLength
+
+Type: `number`\
+Default: `50`
+
+**Note:** Cannot be less than `embeddedProtocolMinLength`.
+
+Duplicate slashes will be removed unless prefixed by a protocol with length greater than or equal to `embeddedProtocolMinLength` and less than or equal to `embeddedProtocolMaxLength`
+```js
+normalizeUrl('www.sindresorhus.com//foo/bar://sindresorhus.com/abcdef://b.com', {
+	embeddedProtocolMaxLength: 5
+});
+//=> 'www.sindresorhus.com/foo/bar://sindresorhus.com/abcdef:/b.com'
+```
+
 ## Related
 
 - [compare-urls](https://github.com/sindresorhus/compare-urls) - Compare URLs by first normalizing them

--- a/test.js
+++ b/test.js
@@ -197,6 +197,18 @@ test('invalid urls', t => {
 	}, 'Invalid URL: /relative/path/');
 });
 
+test('embeddedProtocolMinLength out of bounds', t => {
+	t.throws(() => {
+		normalizeUrl('https://www.sindresorhus.com', {embeddedProtocolMinLength: 0});
+	}, 'The `embeddedProtocolMinLength` option must be greater than 0');
+});
+
+test('embeddedProtocolMaxLength out of bounds', t => {
+	t.throws(() => {
+		normalizeUrl('https://www.sindresorhus.com', {embeddedProtocolMinLength: 5, embeddedProtocolMaxLength: 4});
+	}, 'The `embeddedProtocolMaxLength` option cannot be less than the `embeddedProtocolMinLength`');
+});
+
 test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com////foo/bar'), 'http://sindresorhus.com/foo/bar');
 	t.is(normalizeUrl('http://sindresorhus.com////foo////bar'), 'http://sindresorhus.com/foo/bar');
@@ -205,6 +217,8 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com///foo'), 'http://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com:5000//foo'), 'http://sindresorhus.com:5000/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo'), 'http://sindresorhus.com/foo');
+
+	// Using default embeddedProtocolMin/MaxLength (2/50) options
 	t.is(normalizeUrl('http://sindresorhus.com/s3://sindresorhus.com'), 'http://sindresorhus.com/s3://sindresorhus.com');
 	t.is(normalizeUrl('http://sindresorhus.com/s3://sindresorhus.com//foo'), 'http://sindresorhus.com/s3://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo/s3://sindresorhus.com'), 'http://sindresorhus.com/foo/s3://sindresorhus.com');
@@ -212,8 +226,15 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com/git://sindresorhus.com//foo'), 'http://sindresorhus.com/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo/git://sindresorhus.com//foo'), 'http://sindresorhus.com/foo/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com/a://sindresorhus.com//foo'), 'http://sindresorhus.com/a:/sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds30charlimit:/sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx:/sindresorhus.com/foo');
+
+	// Using custom embeddedProtocolMin/MaxLength (4/10) options
+	const options = {embeddedProtocolMinLength: 4, embeddedProtocolMaxLength: 10};
+	t.is(normalizeUrl('http://sindresorhus.com/abc://sindresorhus.com//foo', options), 'http://sindresorhus.com/abc:/sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/abcd://sindresorhus.com//foo', options), 'http://sindresorhus.com/abcd://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/abcdefghij://sindresorhus.com//foo', options), 'http://sindresorhus.com/abcdefghij://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/abcdefghijk://sindresorhus.com//foo', options), 'http://sindresorhus.com/abcdefghijk:/sindresorhus.com/foo');
 });
 
 test('data URL', t => {

--- a/test.js
+++ b/test.js
@@ -214,6 +214,9 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com/a://sindresorhus.com//foo'), 'http://sindresorhus.com/a:/sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx:/sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/a2-.+://sindresorhus.com'), 'http://sindresorhus.com/a2-.+://sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com/a2-.+_://sindresorhus.com'), 'http://sindresorhus.com/a2-.+_:/sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com/2abc://sindresorhus.com'), 'http://sindresorhus.com/2abc:/sindresorhus.com');
 });
 
 test('data URL', t => {

--- a/test.js
+++ b/test.js
@@ -205,6 +205,13 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com///foo'), 'http://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com:5000//foo'), 'http://sindresorhus.com:5000/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo'), 'http://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/s3://sindresorhus.com'), 'http://sindresorhus.com/s3://sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com/s3://sindresorhus.com//foo'), 'http://sindresorhus.com/s3://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com//foo/s3://sindresorhus.com'), 'http://sindresorhus.com/foo/s3://sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com/git://sindresorhus.com'), 'http://sindresorhus.com/git://sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com/git://sindresorhus.com//foo'), 'http://sindresorhus.com/git://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com//foo/git://sindresorhus.com//foo'), 'http://sindresorhus.com/foo/git://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/a://sindresorhus.com//foo'), 'http://sindresorhus.com/a:/sindresorhus.com/foo');
 });
 
 test('data URL', t => {

--- a/test.js
+++ b/test.js
@@ -212,6 +212,8 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com/git://sindresorhus.com//foo'), 'http://sindresorhus.com/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo/git://sindresorhus.com//foo'), 'http://sindresorhus.com/foo/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com/a://sindresorhus.com//foo'), 'http://sindresorhus.com/a:/sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds30charlimit:/sindresorhus.com/foo');
 });
 
 test('data URL', t => {

--- a/test.js
+++ b/test.js
@@ -197,18 +197,6 @@ test('invalid urls', t => {
 	}, 'Invalid URL: /relative/path/');
 });
 
-test('embeddedProtocolMinLength out of bounds', t => {
-	t.throws(() => {
-		normalizeUrl('https://www.sindresorhus.com', {embeddedProtocolMinLength: 0});
-	}, 'The `embeddedProtocolMinLength` option must be greater than 0');
-});
-
-test('embeddedProtocolMaxLength out of bounds', t => {
-	t.throws(() => {
-		normalizeUrl('https://www.sindresorhus.com', {embeddedProtocolMinLength: 5, embeddedProtocolMaxLength: 4});
-	}, 'The `embeddedProtocolMaxLength` option cannot be less than the `embeddedProtocolMinLength`');
-});
-
 test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com////foo/bar'), 'http://sindresorhus.com/foo/bar');
 	t.is(normalizeUrl('http://sindresorhus.com////foo////bar'), 'http://sindresorhus.com/foo/bar');
@@ -217,8 +205,6 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com///foo'), 'http://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com:5000//foo'), 'http://sindresorhus.com:5000/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo'), 'http://sindresorhus.com/foo');
-
-	// Using default embeddedProtocolMin/MaxLength (2/50) options
 	t.is(normalizeUrl('http://sindresorhus.com/s3://sindresorhus.com'), 'http://sindresorhus.com/s3://sindresorhus.com');
 	t.is(normalizeUrl('http://sindresorhus.com/s3://sindresorhus.com//foo'), 'http://sindresorhus.com/s3://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo/s3://sindresorhus.com'), 'http://sindresorhus.com/foo/s3://sindresorhus.com');
@@ -226,15 +212,8 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com/git://sindresorhus.com//foo'), 'http://sindresorhus.com/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo/git://sindresorhus.com//foo'), 'http://sindresorhus.com/foo/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com/a://sindresorhus.com//foo'), 'http://sindresorhus.com/a:/sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx:/sindresorhus.com/foo');
-
-	// Using custom embeddedProtocolMin/MaxLength (4/10) options
-	const options = {embeddedProtocolMinLength: 4, embeddedProtocolMaxLength: 10};
-	t.is(normalizeUrl('http://sindresorhus.com/abc://sindresorhus.com//foo', options), 'http://sindresorhus.com/abc:/sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/abcd://sindresorhus.com//foo', options), 'http://sindresorhus.com/abcd://sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/abcdefghij://sindresorhus.com//foo', options), 'http://sindresorhus.com/abcdefghij://sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/abcdefghijk://sindresorhus.com//foo', options), 'http://sindresorhus.com/abcdefghijk:/sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds30charlimit:/sindresorhus.com/foo');
 });
 
 test('data URL', t => {

--- a/test.js
+++ b/test.js
@@ -212,8 +212,8 @@ test('remove duplicate pathname slashes', t => {
 	t.is(normalizeUrl('http://sindresorhus.com/git://sindresorhus.com//foo'), 'http://sindresorhus.com/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com//foo/git://sindresorhus.com//foo'), 'http://sindresorhus.com/foo/git://sindresorhus.com/foo');
 	t.is(normalizeUrl('http://sindresorhus.com/a://sindresorhus.com//foo'), 'http://sindresorhus.com/a:/sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin30charlimit://sindresorhus.com/foo');
-	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds30charlimit://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds30charlimit:/sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolwithin50charlimitxxxxxxxxxxxxxxxxxxxx://sindresorhus.com/foo');
+	t.is(normalizeUrl('http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx://sindresorhus.com//foo'), 'http://sindresorhus.com/alongprotocolexceeds50charlimitxxxxxxxxxxxxxxxxxxxxx:/sindresorhus.com/foo');
 });
 
 test('data URL', t => {


### PR DESCRIPTION
Fixes #114 

Prior to this, duplicate slashes would be removed unless preceded by "http" or "https" protocols. This was too strict.

The regex was updated to allow for any 2+ character alphanumeric protocol. Went with requiring at least 2 characters since every scheme listed here (https://en.wikipedia.org/wiki/List_of_URI_schemes) is at least 2 characters.