### PR TITLE
Improve `stripWWW` logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,10 +147,11 @@ const normalizeUrl = (urlString, options) => {
 		urlObj.hostname = urlObj.hostname.replace(/\.$/, '');
 
 		// Remove `www.`
-		if (options.stripWWW && /^www\.(?:[a-z\-\d]{2,63})\.(?:[a-z.]{2,5})$/.test(urlObj.hostname)) {
-			// Each label should be max 63 at length (min: 2).
-			// The extension should be max 5 at length (min: 2).
+		if (options.stripWWW && /^www\.(?!www\.)(?:[a-z\-\d]{1,63})\.(?:[a-z.\-\d]{2,63})$/.test(urlObj.hostname)) {
+			// Each label should be max 63 at length (min: 1).
 			// Source: https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
+			// Each TLD should be up to 63 characters long (min: 2).
+			// It is technically possible to have a single character TLD, but none currently exist.
 			urlObj.hostname = urlObj.hostname.replace(/^www\./, '');
 		}
 	}

--- a/test.js
+++ b/test.js
@@ -75,6 +75,13 @@ test('stripWWW option', t => {
 	t.is(normalizeUrl('www.sindresorhus.com', options), 'http://www.sindresorhus.com');
 	t.is(normalizeUrl('http://www.êxample.com', options), 'http://www.xn--xample-hva.com');
 	t.is(normalizeUrl('sindre://www.sorhus.com', options), 'sindre://www.sorhus.com');
+
+	options.stripWWW = true;
+	t.is(normalizeUrl('http://www.vue.amsterdam', options), 'http://vue.amsterdam');
+	t.is(normalizeUrl('http://www.sorhus.xx--bck1b9a5dre4c', options), 'http://sorhus.xx--bck1b9a5dre4c');
+
+	const tooLongTLDURL = 'http://www.sorhus.' + ''.padEnd(64, 'a');
+	t.is(normalizeUrl(tooLongTLDURL, options), tooLongTLDURL);
 });
 
 test('removeQueryParameters option', t => {

--- a/test.js
+++ b/test.js
@@ -81,7 +81,7 @@ test('stripWWW option', t => {
 	t.is(normalizeUrl('http://www.sorhus.xx--bck1b9a5dre4c', options2), 'http://sorhus.xx--bck1b9a5dre4c');
 
 	const tooLongTLDURL = 'http://www.sorhus.' + ''.padEnd(64, 'a');
-	t.is(normalizeUrl(tooLongTLDURL, options), tooLongTLDURL);
+	t.is(normalizeUrl(tooLongTLDURL, options2), tooLongTLDURL);
 });
 
 test('removeQueryParameters option', t => {

--- a/test.js
+++ b/test.js
@@ -76,9 +76,9 @@ test('stripWWW option', t => {
 	t.is(normalizeUrl('http://www.êxample.com', options), 'http://www.xn--xample-hva.com');
 	t.is(normalizeUrl('sindre://www.sorhus.com', options), 'sindre://www.sorhus.com');
 
-	options.stripWWW = true;
-	t.is(normalizeUrl('http://www.vue.amsterdam', options), 'http://vue.amsterdam');
-	t.is(normalizeUrl('http://www.sorhus.xx--bck1b9a5dre4c', options), 'http://sorhus.xx--bck1b9a5dre4c');
+	const options2 = {stripWWW: true};
+	t.is(normalizeUrl('http://www.vue.amsterdam', options2), 'http://vue.amsterdam');
+	t.is(normalizeUrl('http://www.sorhus.xx--bck1b9a5dre4c', options2), 'http://sorhus.xx--bck1b9a5dre4c');
 
 	const tooLongTLDURL = 'http://www.sorhus.' + ''.padEnd(64, 'a');
 	t.is(normalizeUrl(tooLongTLDURL, options), tooLongTLDURL);


### PR DESCRIPTION
Fixes #116 

* Supports TLDs up to 63 characters. TLDs have the same length restrictions as other DNS labels. There are existing TLDs that are at least 25 characters long.
* Supports single character domains.
* Supports internationalized TLDs (requires allowing for "-" and numeric characters in the TLD): https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#Internationalized_country_code_top-level_domains