### PR TITLE
Fix `removeSingleSlash` option adding slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,8 +175,14 @@ const normalizeUrl = (urlString, options) => {
 		urlObj.pathname = urlObj.pathname.replace(/\/$/, '');
 	}
 
+	const oldUrlString = urlString;
+
 	// Take advantage of many of the Node `url` normalizations
 	urlString = urlObj.toString();
+
+	if (!options.removeSingleSlash && urlObj.pathname === '/' && !oldUrlString.endsWith('/') && urlObj.hash === '') {
+		urlString = urlString.replace(/\/$/, '');
+	}
 
 	// Remove ending `/` unless removeSingleSlash is false
 	if ((options.removeTrailingSlash || urlObj.pathname === '/') && urlObj.hash === '' && options.removeSingleSlash) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,6 +16,7 @@ normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
 	removeQueryParameters: ['ref', /test/]
 });
 normalizeUrl('http://sindresorhus.com/', {removeTrailingSlash: false});
+normalizeUrl('http://sindresorhus.com/', {removeSingleSlash: false});
 normalizeUrl('www.sindresorhus.com/foo/default.php', {
 	removeDirectoryIndex: [/^default\.[a-z]+$/, 'foo']
 });

--- a/test.js
+++ b/test.js
@@ -119,10 +119,15 @@ test('forceHttps option', t => {
 
 test('removeTrailingSlash option', t => {
 	const options = {removeTrailingSlash: false};
+	t.is(normalizeUrl('http://sindresorhus.com'), 'http://sindresorhus.com');
 	t.is(normalizeUrl('http://sindresorhus.com/'), 'http://sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com', options), 'http://sindresorhus.com');
 	t.is(normalizeUrl('http://sindresorhus.com/', options), 'http://sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com/redirect'), 'http://sindresorhus.com/redirect');
 	t.is(normalizeUrl('http://sindresorhus.com/redirect/'), 'http://sindresorhus.com/redirect');
 	t.is(normalizeUrl('http://sindresorhus.com/redirect/', options), 'http://sindresorhus.com/redirect/');
+	t.is(normalizeUrl('http://sindresorhus.com/redirect/', options), 'http://sindresorhus.com/redirect/');
+	t.is(normalizeUrl('http://sindresorhus.com/#/'), 'http://sindresorhus.com/#/');
 	t.is(normalizeUrl('http://sindresorhus.com/#/', options), 'http://sindresorhus.com/#/');
 	t.is(normalizeUrl('http://sindresorhus.com/?unicorns=true'), 'http://sindresorhus.com/?unicorns=true');
 	t.is(normalizeUrl('http://sindresorhus.com/?unicorns=true', options), 'http://sindresorhus.com/?unicorns=true');
@@ -130,7 +135,9 @@ test('removeTrailingSlash option', t => {
 
 test('removeSingleSlash option', t => {
 	const options = {removeSingleSlash: false};
+	t.is(normalizeUrl('https://sindresorhus.com', options), 'https://sindresorhus.com');
 	t.is(normalizeUrl('https://sindresorhus.com/', options), 'https://sindresorhus.com/');
+	t.is(normalizeUrl('https://sindresorhus.com/redirect', options), 'https://sindresorhus.com/redirect');
 	t.is(normalizeUrl('https://sindresorhus.com/redirect/', options), 'https://sindresorhus.com/redirect');
 	t.is(normalizeUrl('https://sindresorhus.com/#/', options), 'https://sindresorhus.com/#/');
 	t.is(normalizeUrl('https://sindresorhus.com/?unicorns=true', options), 'https://sindresorhus.com/?unicorns=true');
@@ -138,7 +145,9 @@ test('removeSingleSlash option', t => {
 
 test('removeSingleSlash option combined with removeTrailingSlash option', t => {
 	const options = {removeTrailingSlash: false, removeSingleSlash: false};
+	t.is(normalizeUrl('https://sindresorhus.com', options), 'https://sindresorhus.com');
 	t.is(normalizeUrl('https://sindresorhus.com/', options), 'https://sindresorhus.com/');
+	t.is(normalizeUrl('https://sindresorhus.com/redirect', options), 'https://sindresorhus.com/redirect');
 	t.is(normalizeUrl('https://sindresorhus.com/redirect/', options), 'https://sindresorhus.com/redirect/');
 	t.is(normalizeUrl('https://sindresorhus.com/#/', options), 'https://sindresorhus.com/#/');
 	t.is(normalizeUrl('https://sindresorhus.com/?unicorns=true', options), 'https://sindresorhus.com/?unicorns=true');


### PR DESCRIPTION
Turns out the option caused single slashes to be added to URLs that had none because the `URL` constructor defaults pathname to `/` both on parse and .toString(), so I had to prevent overwriting `urlString` to be able to check if the passed URL's pathname is `/`.

Also added an entry for the option to `index.test-d.ts`.