### PR TITLE
Add support for custom protocols with the `allowCustomProtocols` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,6 +225,26 @@ declare namespace normalizeUrl {
 		```
 		*/
 		readonly sortQueryParameters?: boolean;
+
+		/**
+		Allows more complex custom protocols.
+
+		@default false
+
+		@example
+		```
+		normalizeUrl('my.mobile.app://sindresorhus.com', {
+			allowCustomProtocols: false
+		});
+		//=> 'http://sindresorhus.com'
+
+		normalizeUrl('my.mobile.app://sindresorhus.com', {
+			allowCustomProtocols: true
+		});
+		//=> 'my.mobile.app://sindresorhus.com'
+		```
+		*/
+		readonly allowCustomProtocols?: boolean;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -236,7 +236,7 @@ declare namespace normalizeUrl {
 		normalizeUrl('my.mobile.app://sindresorhus.com', {
 			allowCustomProtocols: false
 		});
-		//=> 'http://sindresorhus.com'
+		//=> 'http://my.mobile.app/sindresorhus.com'
 
 		normalizeUrl('my.mobile.app://sindresorhus.com', {
 			allowCustomProtocols: true

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ const normalizeUrl = (urlString, options) => {
 		removeSingleSlash: true,
 		removeDirectoryIndex: false,
 		sortQueryParameters: true,
+		allowCustomProtocols: false,
 		...options
 	};
 
@@ -89,10 +90,12 @@ const normalizeUrl = (urlString, options) => {
 	}
 
 	const hasRelativeProtocol = urlString.startsWith('//');
+	// A protocol is deemed custom if it has a period (".") or a plus ("+") in it.
+	const hasCustomProtocol = /^[a-z.+]*[.+][a-z.+]*:\/\//i.test(urlString);
 	const isRelativeUrl = !hasRelativeProtocol && /^\.*\//.test(urlString);
 
 	// Prepend protocol
-	if (!isRelativeUrl) {
+	if (!isRelativeUrl && !(hasCustomProtocol && options.allowCustomProtocols)) {
 		urlString = urlString.replace(/^(?!(?:\w+:)?\/\/)|^\/\//, options.defaultProtocol);
 	}
 
@@ -100,6 +103,18 @@ const normalizeUrl = (urlString, options) => {
 
 	if (options.forceHttp && options.forceHttps) {
 		throw new Error('The `forceHttp` and `forceHttps` options cannot be used together');
+	}
+
+	if (options.allowCustomProtocols && options.stripProtocol) {
+		throw new Error('The `allowCustomProtocols` and `stripProtocol` options cannot be used together');
+	}
+
+	if (options.allowCustomProtocols && options.forceHttp) {
+		throw new Error('The `allowCustomProtocols` and `forceHttp` options cannot be used together');
+	}
+
+	if (options.allowCustomProtocols && options.forceHttps) {
+		throw new Error('The `allowCustomProtocols` and `forceHttps` options cannot be used together');
 	}
 
 	if (options.forceHttp && urlObj.protocol === 'https:') {

--- a/index.js
+++ b/index.js
@@ -90,8 +90,8 @@ const normalizeUrl = (urlString, options) => {
 	}
 
 	const hasRelativeProtocol = urlString.startsWith('//');
-	// A protocol is deemed custom if it has a period (".") or a plus ("+") in it.
-	const hasCustomProtocol = /^[a-z.+]*[.+][a-z.+]*:\/\//i.test(urlString);
+	// A protocol is deemed custom if it has a period ("."), a hypen ("-"), or a plus ("+") in it.
+	const hasCustomProtocol = /^[a-z.+-]*[.+-][a-z.+-]*:\/\//i.test(urlString);
 	const isRelativeUrl = !hasRelativeProtocol && /^\.*\//.test(urlString);
 
 	// Prepend protocol

--- a/readme.md
+++ b/readme.md
@@ -251,6 +251,25 @@ normalizeUrl('www.sindresorhus.com?b=two&a=one&c=three', {
 //=> 'http://sindresorhus.com/?b=two&a=one&c=three'
 ```
 
+##### allowCustomProtocols
+
+Type: `boolean`\
+Default: `false`
+
+Allows more complex custom protocols.
+
+```js
+normalizeUrl('my.mobile.app://sindresorhus.com', {
+	allowCustomProtocols: false
+});
+//=> 'http://sindresorhus.com'
+
+normalizeUrl('my.mobile.app://sindresorhus.com', {
+	allowCustomProtocols: true
+});
+//=> 'my.mobile.app://sindresorhus.com'
+```
+
 ## Related
 
 - [compare-urls](https://github.com/sindresorhus/compare-urls) - Compare URLs by first normalizing them

--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ Allows more complex custom protocols.
 normalizeUrl('my.mobile.app://sindresorhus.com', {
 	allowCustomProtocols: false
 });
-//=> 'http://sindresorhus.com'
+//=> 'http://my.mobile.app/sindresorhus.com'
 
 normalizeUrl('my.mobile.app://sindresorhus.com', {
 	allowCustomProtocols: true

--- a/test.js
+++ b/test.js
@@ -241,6 +241,40 @@ test('sortQueryParameters option', t => {
 	t.is(normalizeUrl('http://sindresorhus.com/', options2), 'http://sindresorhus.com');
 });
 
+test('allowCustomProtocols option', t => {
+	const options1 = {
+		allowCustomProtocols: true
+	};
+	t.is(normalizeUrl('http://sindresorhus.com', options1), 'http://sindresorhus.com');
+	t.is(normalizeUrl('https://sindresorhus.com', options1), 'https://sindresorhus.com');
+	t.is(normalizeUrl('custom://sindresorhus.com', options1), 'custom://sindresorhus.com');
+	t.is(normalizeUrl('custom.with.periods://sindresorhus.com', options1), 'custom.with.periods://sindresorhus.com');
+	t.is(normalizeUrl('custom+with+plusses://sindresorhus.com', options1), 'custom+with+plusses://sindresorhus.com');
+
+	const options2 = {
+		allowCustomProtocols: false
+	};
+	t.is(normalizeUrl('http://sindresorhus.com', options2), 'http://sindresorhus.com');
+	t.is(normalizeUrl('https://sindresorhus.com', options2), 'https://sindresorhus.com');
+	t.is(normalizeUrl('custom://sindresorhus.com', options2), 'custom://sindresorhus.com');
+	t.is(normalizeUrl('custom.with.periods://sindresorhus.com', options2), 'http://custom.with.periods/sindresorhus.com');
+	t.is(normalizeUrl('custom+with+plusses://sindresorhus.com', options2), 'http://custom+with+plusses/sindresorhus.com');
+});
+
+test('allowCustomProtocols option with stripProtocol, forceHttp, forceHttps', t => {
+	t.throws(() => {
+		normalizeUrl('https://www.sindresorhus.com', {allowCustomProtocols: true, stripProtocol: true});
+	}, 'The `allowCustomProtocols` and `stripProtocol` options cannot be used together');
+
+	t.throws(() => {
+		normalizeUrl('https://www.sindresorhus.com', {allowCustomProtocols: true, forceHttp: true});
+	}, 'The `allowCustomProtocols` and `forceHttp` options cannot be used together');
+
+	t.throws(() => {
+		normalizeUrl('https://www.sindresorhus.com', {allowCustomProtocols: true, forceHttps: true});
+	}, 'The `allowCustomProtocols` and `forceHttps` options cannot be used together');
+});
+
 test('invalid urls', t => {
 	t.throws(() => {
 		normalizeUrl('http://');

--- a/test.js
+++ b/test.js
@@ -250,6 +250,7 @@ test('allowCustomProtocols option', t => {
 	t.is(normalizeUrl('custom://sindresorhus.com', options1), 'custom://sindresorhus.com');
 	t.is(normalizeUrl('custom.with.periods://sindresorhus.com', options1), 'custom.with.periods://sindresorhus.com');
 	t.is(normalizeUrl('custom+with+plusses://sindresorhus.com', options1), 'custom+with+plusses://sindresorhus.com');
+	t.is(normalizeUrl('custom-with-hyphens://sindresorhus.com', options1), 'custom-with-hyphens://sindresorhus.com');
 
 	const options2 = {
 		allowCustomProtocols: false
@@ -259,6 +260,7 @@ test('allowCustomProtocols option', t => {
 	t.is(normalizeUrl('custom://sindresorhus.com', options2), 'custom://sindresorhus.com');
 	t.is(normalizeUrl('custom.with.periods://sindresorhus.com', options2), 'http://custom.with.periods/sindresorhus.com');
 	t.is(normalizeUrl('custom+with+plusses://sindresorhus.com', options2), 'http://custom+with+plusses/sindresorhus.com');
+	t.is(normalizeUrl('custom-with-hyphens://sindresorhus.com', options2), 'http://custom-with-hyphens/sindresorhus.com');
 });
 
 test('allowCustomProtocols option with stripProtocol, forceHttp, forceHttps', t => {


### PR DESCRIPTION
We have been having problems with app protocols like "my.app://path/to/something".

A quick looks shows that valid protocols can have periods, hyphens and pluses in them and remain valid.

This PR keeps existing behavior unless the `allowCustomProtocols` option is provided, in which case more complex protocols aren't mangled.

### Changes at a glance
**Before:**
```js
normalizeUrl('my.mobile.app://sindresorhus.com');
//=> 'http://my.mobile.app/sindresorhus.com' ???
```
**After:**
```js
normalizeUrl('my.mobile.app://sindresorhus.com', {
	allowCustomProtocols: true
});
//=> 'my.mobile.app://sindresorhus.com'
```

As you can see the before example doesn't make much sense. I feel like this would probably be a sane default to have enabled, but I don't want to break compatibility, so I'll leave that up to you.