### PR TITLE
Add `useJsRegexpLookbehind` option (#105)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,6 +242,13 @@ export interface Options {
 	```
 	*/
 	readonly sortQueryParameters?: boolean;
+
+	/**
+	prefer js-regexp-lookbehind{@link https://caniuse.com/js-regexp-lookbehind}
+
+	@default true
+	*/
+	readonly preferJsRegexpLookbehind?: boolean;
 }
 
 /**


### PR DESCRIPTION
As SyntaxError can not be try-catch, use `new RegExp` to avoid js parser error.