### PR TITLE
Add support for custom protocols

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,10 @@ export default function normalizeUrl(urlString, options) {
 
 	const hasRelativeProtocol = urlString.startsWith('//');
 	const isRelativeUrl = !hasRelativeProtocol && /^\.*\//.test(urlString);
+	const hasCustomProtocol = /^[a-z.+-]*[.+-][a-z.+-]*:\/\//i.test(urlString);
 
 	// Prepend protocol
-	if (!isRelativeUrl) {
+	if (!isRelativeUrl & !hasCustomProtocol) {
 		urlString = urlString.replace(/^(?!(?:\w+:)?\/\/)|^\/\//, options.defaultProtocol);
 	}
 

--- a/test.js
+++ b/test.js
@@ -394,3 +394,10 @@ test('does not have exponential performance for data URLs', t => {
 		t.true(difference < 100, `Execution time: ${difference}`);
 	}
 });
+
+test('supports custom protocol', t => {
+	t.is(normalizeUrl('custom://sindresorhus.com'), 'custom://sindresorhus.com');
+	t.is(normalizeUrl('custom+with+plusses://sindresorhus.com'), 'custom+with+plusses://sindresorhus.com');
+	t.is(normalizeUrl('custom.with.periods://sindresorhus.com'), 'custom.with.periods://sindresorhus.com');
+	t.is(normalizeUrl('custom-with-hyphens://sindresorhus.com'), 'custom-with-hyphens://sindresorhus.com');
+});


### PR DESCRIPTION
I may be oversimplifying here, but this feels like a bug fix to not apply the protocol prefix when a custom prefix is present.  Retains existing functionality and adds support for custom protocols.  Closes #152.