### PR TITLE
Fixed typos in sortQueryParams docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,7 @@ Sorts the query parameters alphabetically by key.
 normalizeUrl('www.sindresorhus.com?b=two&a=one&c=three', {
 	sortQueryParameters: false
 });
-//=> 'http://sindresorhus.com/?b=two&a=one&c=three'
+//=> 'http://sindresorhus.com/?a=one&b=two&c=three'
 ```
 
 ## Related


### PR DESCRIPTION
Hello, I found a typo at the `README.md` of your repo. Specifically in the `sortQueryParameters` example the initial URL is **www.sindresorhus.com?b=two&a=one&c=three** and the output **http://sindresorhus.com/?b=two&a=one&c=three**. The query params are not sorted 