### PR TITLE
Add keepQueryParameters option (#172)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -180,6 +180,21 @@ export interface Options {
 	readonly removeQueryParameters?: ReadonlyArray<RegExp | string> | boolean;
 
 	/**
+	Keeps query parameters that matches any of the provided strings or regexes.
+
+	@default []
+
+	@example
+	```
+	normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
+		keepQueryParameters: ['ref']
+	});
+	//=> 'http://sindresorhus.com/?ref=test_ref'
+	```
+	 */
+	readonly keepQueryParameters?: ReadonlyArray<RegExp | string>;
+
+	/**
 	Removes trailing slash.
 
 	__Note__: Trailing slash is always removed if the URL doesn't have a pathname unless the `removeSingleSlash` option is set to `false`.

--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ export default function normalizeUrl(urlString, options) {
 		stripTextFragment: true,
 		stripWWW: true,
 		removeQueryParameters: [/^utm_\w+/i],
+		keepQueryParameters: [],
 		removeTrailingSlash: true,
 		removeSingleSlash: true,
 		removeDirectoryIndex: false,
@@ -202,6 +203,16 @@ export default function normalizeUrl(urlString, options) {
 
 	if (options.removeQueryParameters === true) {
 		urlObject.search = '';
+	}
+
+	// Keep wanted query parameters
+	if (Array.isArray(options.keepQueryParameters) && options.keepQueryParameters.length > 0) {
+		// eslint-disable-next-line unicorn/no-useless-spread -- We are intentionally spreading to get a copy.
+		for (const key of [...urlObject.searchParams.keys()]) {
+			if (!testParameter(key, options.keepQueryParameters)) {
+				urlObject.searchParams.delete(key);
+			}
+		}
 	}
 
 	// Sort query parameters

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,6 +21,9 @@ normalizeUrl('www.sindresorhus.com?foo=bar', {
 normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', {
 	removeQueryParameters: false,
 });
+normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
+	keepQueryParameters: ['ref', /test/],
+});
 normalizeUrl('http://sindresorhus.com/', {removeTrailingSlash: false});
 normalizeUrl('http://sindresorhus.com/', {removeSingleSlash: false});
 normalizeUrl('www.sindresorhus.com/foo/default.php', {

--- a/readme.md
+++ b/readme.md
@@ -210,6 +210,20 @@ normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', {
 //=> 'http://www.sindresorhus.com/?foo=bar&ref=test_ref&utm_medium=test'
 ```
 
+##### keepQueryParameters
+
+Type: `Array<RegExp | string>`\
+Default: `[]`
+
+Keep query parameters that matches any of the provided strings or regexes.
+
+```js
+normalizeUrl('www.sindresorhus.com?foo=bar&ref=test_ref', {
+	keepQueryParameters: ['ref']
+});
+//=> 'http://sindresorhus.com/?ref=test_ref'
+```
+
 ##### removeTrailingSlash
 
 Type: `boolean`\

--- a/test.js
+++ b/test.js
@@ -141,6 +141,17 @@ test('removeQueryParameters boolean `false` option', t => {
 	t.is(normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', options), 'http://www.sindresorhus.com/?foo=bar&ref=test_ref&utm_medium=test');
 });
 
+test('keepQueryParameters option', t => {
+	const options = {
+		stripWWW: false,
+		removeQueryParameters: false,
+		keepQueryParameters: [/^utm_\w+/i, 'ref'],
+	};
+	t.is(normalizeUrl('http://www.sindresorhus.com', options), 'http://www.sindresorhus.com');
+	t.is(normalizeUrl('www.sindresorhus.com?foo=bar', options), 'http://www.sindresorhus.com');
+	t.is(normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', options), 'http://www.sindresorhus.com/?ref=test_ref&utm_medium=test');
+});
+
 test('forceHttp option', t => {
 	const options = {forceHttp: true};
 	t.is(normalizeUrl('https://sindresorhus.com'), 'https://sindresorhus.com');


### PR DESCRIPTION
Hi.
I added `keepQueryParameters` option. (#172)
It conflicts with the `removeQueryParameters` option and I'm not sure what we should do. Maybe it would be nice to add a note to the documentation.