### PR TITLE
Feat: add remove explicit port option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -250,6 +250,22 @@ export interface Options {
 	readonly removeDirectoryIndex?: boolean | ReadonlyArray<RegExp | string>;
 
 	/**
+	Removes a port number corresponding to the protocol part of a url, excluding a default port
+	number e.g., 80 for http, and 443 for https.
+
+	@default false
+
+	@example
+	```
+	normalizeUrl('sindresorhus.com:123', {
+		removeExplicitPort: true
+	});
+	//=> 'sindresorhus.com'
+	```
+	*/
+	readonly removeExplicitPort?: boolean;
+
+	/**
 	Sorts the query parameters alphabetically by key.
 
 	@default true

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ export default function normalizeUrl(urlString, options) {
 		removeTrailingSlash: true,
 		removeSingleSlash: true,
 		removeDirectoryIndex: false,
+		removeExplicitPort: false,
 		sortQueryParameters: true,
 		...options,
 	};
@@ -226,6 +227,11 @@ export default function normalizeUrl(urlString, options) {
 
 	if (options.removeTrailingSlash) {
 		urlObject.pathname = urlObject.pathname.replace(/\/$/, '');
+	}
+
+	// Remove an explicit port number, excluding a default port number, if applicable
+	if (options.removeExplicitPort && urlObject.port) {
+		urlObject.port = '';
 	}
 
 	const oldUrlString = urlString;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -29,6 +29,7 @@ normalizeUrl('http://sindresorhus.com/', {removeSingleSlash: false});
 normalizeUrl('www.sindresorhus.com/foo/default.php', {
 	removeDirectoryIndex: [/^default\.[a-z]+$/, 'foo'],
 });
+normalizeUrl('www.sindresorhus.com/', {removeExplicitPort: false});
 normalizeUrl('www.sindresorhus.com?b=two&a=one&c=three', {
 	sortQueryParameters: false,
 });

--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,34 @@ normalizeUrl('www.sindresorhus.com/foo/default.php', {
 //=> 'http://sindresorhus.com/foo'
 ```
 
+##### removeExplicitPort
+
+Type: `boolean`\
+Default: `false`
+
+Removes a port number corresponding to the protocol part of a url, excluding a default port number e.g., 80 for http, and 443 for https.
+
+```js
+normalizeUrl('sindresorhus.com:123', {
+	removeExplicitPort: true
+});
+//=> 'sindresorhus.com'
+```
+
+```js
+normalizeUrl('http://sindresorhus.com:443', {
+	removeExplicitPort: true
+});
+//=> 'http://sindresorhus.com'
+```
+
+```js
+normalizeUrl('https://sindresorhus.com:80', {
+	removeExplicitPort: true
+});
+//=> 'https://sindresorhus.com'
+```
+
 ##### sortQueryParameters
 
 Type: `boolean`\

--- a/test.js
+++ b/test.js
@@ -192,6 +192,14 @@ test('removeTrailingSlash option', t => {
 	t.is(normalizeUrl('http://sindresorhus.com/?unicorns=true', options), 'http://sindresorhus.com/?unicorns=true');
 });
 
+test('removeExplicitPort option', t => {
+	const options = {removeExplicitPort: true};
+	t.is(normalizeUrl('http://sindresorhus.com:123', options), 'http://sindresorhus.com');
+	t.is(normalizeUrl('https://sindresorhus.com:123', options), 'https://sindresorhus.com');
+	t.is(normalizeUrl('http://sindresorhus.com:443', options), 'http://sindresorhus.com');
+	t.is(normalizeUrl('https://sindresorhus.com:80', options), 'https://sindresorhus.com');
+});
+
 test('removeSingleSlash option', t => {
 	const options = {removeSingleSlash: false};
 	t.is(normalizeUrl('https://sindresorhus.com', options), 'https://sindresorhus.com');


### PR DESCRIPTION
**Feature added:** Removes a port number corresponding to the protocol part of a url, excluding a default port number e.g., 80 for http, and 443 for https.
	
	
Relevant link: https://github.com/sindresorhus/normalize-url/issues/171#issuecomment-1235850295