### PR TITLE
Add removeQueryParametersByValue option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -180,6 +180,30 @@ export interface Options {
 	readonly removeQueryParameters?: ReadonlyArray<RegExp | string> | boolean;
 
 	/**
+	Removes query parameters that matches specified value. May be helpful to make canonical URL.
+
+	@default undefined
+
+	@example
+	```
+	normalizeUrl('www.sindresorhus.com?foo=bar&page=1&page_size=30', {
+		removeQueryParametersByValue: [
+			{
+				key: 'page',
+				value: 1
+			},
+			{
+				key: 'page_size',
+				value: 10
+			}
+		]
+	});
+	//=> 'http://sindresorhus.com/?foo=bar&page_size=30'
+	```
+	*/
+	readonly removeQueryParametersByValue?: ReadonlyArray<{key: string; value: string | number}> | undefined;
+
+	/**
 	Keeps only query parameters that matches any of the provided strings or regexes.
 
 	__Note__: It overrides the `removeQueryParameters` option.
@@ -286,7 +310,7 @@ export interface Options {
 [Normalize](https://en.wikipedia.org/wiki/URL_normalization) a URL.
 
 @param url - URL to normalize, including [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
-
+@param options — options
 @example
 ```
 import normalizeUrl from 'normalize-url';

--- a/index.js
+++ b/index.js
@@ -201,6 +201,24 @@ export default function normalizeUrl(urlString, options) {
 		}
 	}
 
+	// Remove query unwanted parameters by an unwanted specified value
+	if (Array.isArray(options.removeQueryParametersByValue) && options.removeQueryParametersByValue.length > 0) {
+		// eslint-disable-next-line unicorn/no-useless-spread -- We are intentionally spreading to get a copy.
+		for (const key of [...urlObject.searchParams.keys()]) {
+			// Support for multiple non-unique parameters
+			const filteredQueryParametersByKey = options
+				.removeQueryParametersByValue
+				.filter(item => item.key === key);
+
+			for (const item of filteredQueryParametersByKey) {
+				// Remove when values are same
+				if (urlObject.searchParams.has(key) && String(item.value) === urlObject.searchParams.get(key)) {
+					urlObject.searchParams.delete(key);
+				}
+			}
+		}
+	}
+
 	if (!Array.isArray(options.keepQueryParameters) && options.removeQueryParameters === true) {
 		urlObject.search = '';
 	}

--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,28 @@ normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', {
 });
 //=> 'http://www.sindresorhus.com/?foo=bar&ref=test_ref&utm_medium=test'
 ```
+##### removeQueryParametersByValue
+
+Removes query parameters that match the specified values. May be helpful to make a canonical URL.
+
+Type: `Array<{ key: string; value: string | number; }>`\
+Default: `undefined`
+
+```js
+normalizeUrl('www.sindresorhus.com?foo=bar&page=1&page_size=30', {
+	removeQueryParametersByValue: [
+		{
+			key: 'page',
+			value: 1
+		},
+		{
+			key: 'page_size',
+			value: 10
+		}
+	]
+});
+//=> 'http://sindresorhus.com/?foo=bar&page_size=30'
+```
 
 ##### keepQueryParameters
 

--- a/test.js
+++ b/test.js
@@ -141,6 +141,28 @@ test('removeQueryParameters boolean `false` option', t => {
 	t.is(normalizeUrl('www.sindresorhus.com?foo=bar&utm_medium=test&ref=test_ref', options), 'http://www.sindresorhus.com/?foo=bar&ref=test_ref&utm_medium=test');
 });
 
+test('removeQueryParametersByValue option', t => {
+	const options = {
+		stripWWW: false,
+		removeQueryParametersByValue: [
+			{
+				key: 'page',
+				value: 1,
+				type: Number,
+			},
+			{
+				key: 'page_size',
+				value: 10,
+				type: Number,
+			},
+		],
+	};
+
+	t.is(normalizeUrl('http://www.sindresorhus.com/?page=1&page_size=10', options), 'http://www.sindresorhus.com');
+	t.is(normalizeUrl('www.sindresorhus.com?foo=bar&page=2&page_size=10', options), 'http://www.sindresorhus.com/?foo=bar&page=2');
+	t.is(normalizeUrl('www.sindresorhus.com?foo=bar&page=2&page_size=20', options), 'http://www.sindresorhus.com/?foo=bar&page=2&page_size=20');
+});
+
 test('keepQueryParameters option', t => {
 	const options = {
 		stripWWW: false,


### PR DESCRIPTION
The option `removeQueryParametersByValue` removes query parameters that match the specified values. May be helpful to make a canonical URL.

```js
normalizeUrl('www.sindresorhus.com?foo=bar&page=1&page_size=30', {
	removeQueryParametersByValue: [
		{
			key: 'page',
			value: 1
		},
		{
			key: 'page_size',
			value: 10
		}
	]
});
//=> 'http://sindresorhus.com/?foo=bar&page_size=30'
```